### PR TITLE
Allow sorting by multiple expressions

### DIFF
--- a/src/OpenDiffix.Core/Expression.fs
+++ b/src/OpenDiffix.Core/Expression.fs
@@ -1,12 +1,12 @@
 namespace OpenDiffix.Core
 
 type Value =
-  | String of string
+  | Null
+  | Boolean of bool
   | Integer of int
   | Float of float
-  | Boolean of bool
+  | String of string
   | Unit
-  | Null
 
 type Row = Value array
 
@@ -154,11 +154,12 @@ module Expression =
     let sortedRows =
       match opts.OrderBy, opts.OrderByDirection with
       | [], _ -> rows
-      | [ orderByExpr ], Ascending -> rows |> Seq.sortBy (fun row -> evaluate ctx row orderByExpr)
-      | [ orderByExpr ], Descending ->
+      | exprs, Ascending ->
           rows
-          |> Seq.sortByDescending (fun row -> evaluate ctx row orderByExpr)
-      | _ -> failwith "Multiple order by expressions are not supported yet."
+          |> Seq.sortBy (fun row -> exprs |> List.map (evaluate ctx row))
+      | exprs, Descending ->
+          rows
+          |> Seq.sortByDescending (fun row -> exprs |> List.map (evaluate ctx row))
 
     let projectedArgs =
       sortedRows


### PR DESCRIPTION
Also define a sort order in the discriminated union. Comparisons of DU follow the logic of:

1. Earlier union cases have lower sort value.
2. If equal union case, compare case values.

One obvious flaw to this is that an `Integer x` will be considered smaller than the same `Float x` if a set being ordered contains mixed values. We suppose that won't happen because we will be using strongly typed columns. Alternatively, we can write a custom comparison function which checks for this, and possibly for `NULLS FIRST/NULLS LAST` modifier. 