### PR TITLE
Improve failure messages for query engine tests.

### DIFF
--- a/src/OpenDiffix.Core.Tests/QueryEngine.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/QueryEngine.Tests.fs
@@ -29,9 +29,11 @@ let ``SHOW TABLES`` () =
     [ "customers"; "products"; "purchases" ]
     |> List.map (fun v -> [ StringValue v ])
 
-  let expected = { Columns = [ "name" ]; Rows = rows } |> Ok
+  let expected = { Columns = [ "name" ]; Rows = rows }
 
-  Assert.Equal(expected, runQuery "SHOW TABLES")
+  let queryResult = runQuery "SHOW TABLES"
+
+  assertOkEqual queryResult expected
 
 [<Fact>]
 let ``SHOW columns FROM customers`` () =
@@ -46,10 +48,11 @@ let ``SHOW columns FROM customers`` () =
     |> List.sortBy (fun (name, _type) -> name)
     |> List.map (fun (name, dataType) -> [ StringValue name; StringValue dataType ])
 
-  let expected = { Columns = [ "name"; "type" ]; Rows = rows } |> Ok
+  let expected = { Columns = [ "name"; "type" ]; Rows = rows }
 
   let queryResult = runQuery "SHOW columns FROM customers"
-  Assert.Equal(expected, queryResult)
+
+  assertOkEqual queryResult expected
 
 [<Fact>]
 let ``SELECT city FROM customers`` () =
@@ -57,7 +60,7 @@ let ``SELECT city FROM customers`` () =
     [ "Berlin", 77; "London", 25; "Madrid", 25; "Paris", 26; "Rome", 50 ]
     |> List.collect (fun (city, occurrences) -> List.replicate occurrences [ StringValue city ])
 
-  let expected = { Columns = [ "city" ]; Rows = rows } |> Ok
+  let expected = { Columns = [ "city" ]; Rows = rows }
 
   let queryResult =
     match runQuery "SELECT city FROM customers" with
@@ -66,7 +69,7 @@ let ``SELECT city FROM customers`` () =
         { result with Rows = sortedRows } |> Ok
     | other -> other
 
-  Assert.Equal(expected, queryResult)
+  assertOkEqual queryResult expected
 
 [<Fact>]
 let ``SELECT pid FROM purchases`` () =
@@ -74,7 +77,7 @@ let ``SELECT pid FROM purchases`` () =
     [ 1, 67; 2, 58; 3, 64; 4, 63; 5, 70; 6, 59; 7, 58; 8, 64 ]
     |> List.collect (fun (pid, occurrences) -> List.replicate occurrences [ IntegerValue pid ])
 
-  let expected = { Columns = [ "pid" ]; Rows = rows } |> Ok
+  let expected = { Columns = [ "pid" ]; Rows = rows }
 
   let queryResult =
     match runQuery "SELECT pid FROM purchases" with
@@ -83,4 +86,4 @@ let ``SELECT pid FROM purchases`` () =
         { result with Rows = sortedRows } |> Ok
     | other -> other
 
-  Assert.Equal(expected, queryResult)
+  assertOkEqual queryResult expected


### PR DESCRIPTION
This was really bothering me, since the previous version wasn't showing anything useful on failure.
I also spent ages trying to figure out why FsUnit wasn't working properly here :(.