### PR TITLE
A table win an index would crash schema detection

### DIFF
--- a/src/OpenDiffix.Core/SQLite.fs
+++ b/src/OpenDiffix.Core/SQLite.fs
@@ -28,7 +28,7 @@ let dbSchema (connection: SQLiteConnection) =
     FROM sqlite_master m
          left outer join pragma_table_info((m.name)) p
              on m.name <> p.name
-    WHERE tableName NOT LIKE 'sqlite%'
+    WHERE tableName NOT LIKE 'sqlite%' and m.type = 'table'
     ORDER by tableName, columnName
     """
 


### PR DESCRIPTION
The indices would be returned by the SELECT statement used
to discover columns and column types, but the fields for
name and type would be null. Apart from not being something
that should have been included in the detected schema, it
also caused the app to crash.