### PR TITLE
Implement `diffix_count(distinct)` aggregator.

### DIFF
--- a/src/OpenDiffix.Core.Tests/Anonymizer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Anonymizer.Tests.fs
@@ -1,0 +1,27 @@
+module OpenDiffix.Core.AnonymizerTests
+
+open Xunit
+open FsUnit.Xunit
+open OpenDiffix.Core
+
+let ctx = EvaluationContext.Default
+
+let ids =
+  [ 1, 5; 2, 4; 3, 2; 4, 1; 5, 5; 6, 4; 7, 3 ]
+  |> List.collect (fun (id, count) -> List.replicate id count)
+  |> List.map (int64 >> Integer >> Array.singleton)
+
+let idColumn = ColumnReference(0, IntegerType)
+
+let context = EvaluationContext.Default
+
+let evalAggr fn args rows =
+  let processor = fun (acc: Expression.Accumulator) row -> acc.Process ctx args row
+  let accumulator = List.fold processor (Expression.createAccumulator ctx fn) rows
+  accumulator.Evaluate context
+
+[<Fact>]
+let ``anon count distinct 1`` () =
+  let diffixCountDistinct = AggregateFunction(DiffixCount, { AggregateOptions.Default with Distinct = true })
+  // select count(distinct val_str)
+  ids |> evalAggr diffixCountDistinct [ idColumn ] |> should equal (Integer 8L)

--- a/src/OpenDiffix.Core.Tests/Executor.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Executor.Tests.fs
@@ -23,7 +23,9 @@ type Tests(db: DBFixture) =
   let countDistinct expression =
     FunctionExpr(AggregateFunction(Count, { Distinct = true; OrderBy = [] }), [ expression ])
 
-  let execute plan = plan |> Executor.execute db.Connection |> Seq.toList
+  let context = EvaluationContext.Default
+
+  let execute plan = plan |> Executor.execute db.Connection context |> Seq.toList
 
   [<Fact>]
   let ``execute scan`` () =

--- a/src/OpenDiffix.Core.Tests/Expression.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Expression.Tests.fs
@@ -4,7 +4,7 @@ open Xunit
 open FsUnit.Xunit
 open OpenDiffix.Core
 
-let ctx = EmptyContext
+let ctx = EvaluationContext.Default
 
 module DefaultFunctionsTests =
   let runs fn expectations =
@@ -135,7 +135,7 @@ let eval expr = Expression.evaluate ctx testRow expr
 let evalAggr fn args =
   let processor = fun (acc: Expression.Accumulator) row -> acc.Process ctx args row
   let accumulator = List.fold processor (Expression.createAccumulator ctx fn) testRows
-  accumulator.Evaluate
+  accumulator.Evaluate ctx
 
 [<Fact>]
 let evaluate () =

--- a/src/OpenDiffix.Core.Tests/OpenDiffix.Core.Tests.fsproj
+++ b/src/OpenDiffix.Core.Tests/OpenDiffix.Core.Tests.fsproj
@@ -4,11 +4,11 @@
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="TestHelpers.fs" />
     <Compile Include="Value.Tests.fs" />
     <Compile Include="Expression.Tests.fs" />
+    <Compile Include="Anonymizer.Tests.fs" />
     <Compile Include="Analyzer.Tests.fs" />
     <Compile Include="Analysis\QueryValidity.Tests.fs" />
     <Compile Include="Parser.Tests.fs" />

--- a/src/OpenDiffix.Core.Tests/QueryEngine.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/QueryEngine.Tests.fs
@@ -45,5 +45,12 @@ type Tests(db: DBFixture) =
 
     assertOkEqual queryResult expected
 
+  [<Fact>]
+  let ``query 4`` () =
+    let expected = { Columns = [ "diffix_count" ]; Rows = [ [| Integer 9L |] ] }
+
+    let queryResult = runQuery "SELECT DIFFIX_COUNT(DISTINCT id) FROM products"
+
+    assertOkEqual queryResult expected
 
   interface IClassFixture<DBFixture>

--- a/src/OpenDiffix.Core/Anonymizer.fs
+++ b/src/OpenDiffix.Core/Anonymizer.fs
@@ -5,36 +5,26 @@ open OpenDiffix.Core.AnonymizerTypes
 
 let private randomUniform (rnd: Random) lower upper = rnd.Next(lower, upper + 1)
 
-let private randomNum (rnd: Random) mean stdDev =
+let private randomNormal (rnd: Random) stdDev =
   let u1 = 1.0 - rnd.NextDouble()
   let u2 = 1.0 - rnd.NextDouble()
 
   let randStdNormal = Math.Sqrt(-2.0 * log (u1)) * Math.Sin(2.0 * Math.PI * u2)
 
-  mean + stdDev * randStdNormal
+  stdDev * randStdNormal
 
 let private newRandom (anonymizationParams: AnonymizationParams) = Random(anonymizationParams.Seed)
 
-let private lowCountFilter (anonymizationParams: AnonymizationParams) rnd (rows: PersonalRows) =
-  let threshold = anonymizationParams.LowCountThreshold
-
-  rows
-  |> List.groupBy (fun row -> row.RowValues)
-  |> List.filter (fun (_values, instancesOfRow) ->
-    let distinctUsersCount =
-      instancesOfRow
-      |> List.map (fun row -> row.AidValues)
-      |> Set.unionMany
-      |> Set.count
-
-    let lowCountThreshold = randomUniform rnd threshold.Lower threshold.Upper
-    distinctUsersCount >= lowCountThreshold
-  )
-  |> List.collect (fun (_values, instancesOfRow) -> instancesOfRow)
-
-let anonymize (anonymizationParams: AnonymizationParams) (rows: PersonalRows) =
+let noisyCount (anonymizationParams: AnonymizationParams) count =
   let rnd = newRandom anonymizationParams
+  let noiseParams = anonymizationParams.Noise
 
-  rows
-  |> lowCountFilter anonymizationParams rnd
-  |> List.map (fun anonymizedRow -> anonymizedRow.RowValues)
+  let noise =
+    noiseParams.StandardDev
+    |> randomNormal rnd
+    |> max -noiseParams.Cutoff
+    |> min noiseParams.Cutoff
+    |> round
+    |> int
+
+  max (count + noise) 0

--- a/src/OpenDiffix.Core/AnonymizerTypes.fs
+++ b/src/OpenDiffix.Core/AnonymizerTypes.fs
@@ -18,10 +18,7 @@ type NoiseParam =
 
   static member Default = { StandardDev = 2.; Cutoff = 5. }
 
-type TableSettings =
-  {
-    AidColumns: string list
-  }
+type TableSettings = { AidColumns: string list }
 
 type AnonymizationParams =
   {
@@ -35,18 +32,12 @@ type AnonymizationParams =
     Noise: NoiseParam
   }
 
-type ColumnValue =
-  | IntegerValue of int
-  | StringValue of string
-  | NullValue
-
-  static member ToString =
-    function
-    | IntegerValue value -> $"%i{value}"
-    | StringValue value -> value
-    | NullValue -> "<null>"
-
-type NonPersonalRow = ColumnValue list
-type NonPersonalRows = NonPersonalRow list
-type PersonalRow = { AidValues: ColumnValue Set; RowValues: NonPersonalRow }
-type PersonalRows = PersonalRow list
+  static member Default =
+    {
+      TableSettings = Map.empty
+      Seed = 0
+      LowCountThreshold = Threshold.Default
+      OutlierCount = Threshold.Default
+      TopCount = Threshold.Default
+      Noise = NoiseParam.Default
+    }

--- a/src/OpenDiffix.Core/Executor.fs
+++ b/src/OpenDiffix.Core/Executor.fs
@@ -4,17 +4,17 @@ open OpenDiffix.Core.PlannerTypes
 
 let private executeScan connection table = table |> Table.load connection |> Async.RunSynchronously |> Utils.unwrap
 
-let private executeProject expressions rowsStream =
+let private executeProject context expressions rowsStream =
   let expressions = Array.ofList expressions
 
   rowsStream
-  |> Seq.map (fun row -> expressions |> Array.map (Expression.evaluate EmptyContext row))
+  |> Seq.map (fun row -> expressions |> Array.map (Expression.evaluate context row))
 
-let private executeFilter condition rowsStream =
+let private executeFilter context condition rowsStream =
   rowsStream
-  |> Seq.filter (fun row -> condition |> Expression.evaluate EmptyContext row |> Value.isTruthy)
+  |> Seq.filter (fun row -> condition |> Expression.evaluate context row |> Value.isTruthy)
 
-let private executeSort orderings rowsStream = rowsStream |> Expression.sortRows EmptyContext orderings
+let private executeSort context orderings rowsStream = rowsStream |> Expression.sortRows context orderings
 
 let private unpackAggregator =
   function
@@ -23,10 +23,10 @@ let private unpackAggregator =
 
 let private unpackAggregators aggregators = aggregators |> Array.map (unpackAggregator) |> Array.unzip
 
-let private executeAggregate groupingLabels aggregators rowsStream =
+let private executeAggregate context groupingLabels aggregators rowsStream =
   let groupingLabels = Array.ofList groupingLabels
   let aggFns, aggArgs = aggregators |> Array.ofList |> unpackAggregators
-  let defaultAccumulators = aggFns |> Array.map (Expression.createAccumulator EmptyContext)
+  let defaultAccumulators = aggFns |> Array.map (Expression.createAccumulator context)
 
   let initialState: Map<Row, Expression.Accumulator array> =
     if groupingLabels.Length = 0 then Map [ [||], defaultAccumulators ] else Map []
@@ -34,29 +34,32 @@ let private executeAggregate groupingLabels aggregators rowsStream =
   rowsStream
   |> Seq.fold
     (fun state row ->
-      let group = groupingLabels |> Array.map (Expression.evaluate EmptyContext row)
+      let group = groupingLabels |> Array.map (Expression.evaluate context row)
 
       let accumulator =
         match Map.tryFind group state with
         | Some accumulator -> accumulator
         | None -> defaultAccumulators
         |> Array.zip aggArgs
-        |> Array.map (fun (args, accumulator) -> accumulator.Process EmptyContext args row)
+        |> Array.map (fun (args, accumulator) -> accumulator.Process context args row)
 
       Map.add group accumulator state
     )
     initialState
   |> Map.toSeq
   |> Seq.map (fun (group, accumulators) ->
-    let values = accumulators |> Array.map (fun acc -> acc.Evaluate)
+    let values = accumulators |> Array.map (fun acc -> acc.Evaluate context)
     Array.append group values
   )
 
-let rec execute connection plan =
+let rec execute connection context plan =
   match plan with
   | Plan.Scan table -> executeScan connection table
-  | Plan.Project (plan, expressions) -> plan |> execute connection |> executeProject expressions
-  | Plan.Filter (plan, condition) -> plan |> execute connection |> executeFilter condition
-  | Plan.Sort (plan, expressions) -> plan |> execute connection |> executeSort expressions
-  | Plan.Aggregate (plan, labels, aggregators) -> plan |> execute connection |> executeAggregate labels aggregators
+  | Plan.Project (plan, expressions) -> plan |> execute connection context |> executeProject context expressions
+  | Plan.Filter (plan, condition) -> plan |> execute connection context |> executeFilter context condition
+  | Plan.Sort (plan, expressions) -> plan |> execute connection context |> executeSort context expressions
+  | Plan.Aggregate (plan, labels, aggregators) ->
+      plan
+      |> execute connection context
+      |> executeAggregate context labels aggregators
   | _ -> failwith "Plan execution not implemented"

--- a/src/OpenDiffix.Core/OpenDiffix.Core.fsproj
+++ b/src/OpenDiffix.Core/OpenDiffix.Core.fsproj
@@ -7,17 +7,17 @@
     <Compile Include="Value.fs" />
     <Compile Include="SQLite.fs" />
     <Compile Include="Table.fs" />
+    <Compile Include="AnonymizerTypes.fs" />
+    <Compile Include="Anonymizer.fs" />
     <Compile Include="Expression.fs" />
     <Compile Include="ParserTypes.fs" />
     <Compile Include="Parser.fs" />
     <Compile Include="AnalyzerTypes.fs" />
-    <Compile Include="AnonymizerTypes.fs" />
     <Compile Include="Analysis\QueryValidity.fs" />
     <Compile Include="Analyzer.fs" />
     <Compile Include="PlannerTypes.fs" />
     <Compile Include="Planner.fs" />
     <Compile Include="Executor.fs" />
-    <Compile Include="Anonymizer.fs" />
     <Compile Include="QueryEngine.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/OpenDiffix.Core/QueryEngine.fs
+++ b/src/OpenDiffix.Core/QueryEngine.fs
@@ -25,7 +25,8 @@ module QueryEngine =
 
       let plan = Planner.plan query
 
-      let rows = plan |> Executor.execute connection |> Seq.toList
+      let context = { AnonymizationParams = anonParams }
+      let rows = plan |> Executor.execute connection context |> Seq.toList
 
       let columns = extractColumnNames query
 


### PR DESCRIPTION
Also adds anonymization parameters to expression evaluation context and propagates that when executing a query plan.