### PR TITLE
Quote column names in query to SQLite

### DIFF
--- a/src/OpenDiffix.Core/Table.fs
+++ b/src/OpenDiffix.Core/Table.fs
@@ -61,7 +61,7 @@ module Table =
   let load connection table =
     let columns =
       table.Columns
-      |> List.map (fun column -> column.Name)
+      |> List.map (fun column -> $"\"%s{column.Name}\"")
       |> List.reduce (sprintf "%s, %s")
 
     let loadQuery = $"SELECT {columns} FROM {table.Name}"


### PR DESCRIPTION
A database created by Paul has an index, with an associated column called `index`. 
The `Table.load` command generated an SQL query akin to `SELECT col1, col2, index, col3 FROM table`, but selecting a column called `index` caused SQLite to reject the query.