### PR TITLE
Normalize aggregation phase names to those of Postgres

### DIFF
--- a/src/OpenDiffix.Core.Tests/TestHelpers.fs
+++ b/src/OpenDiffix.Core.Tests/TestHelpers.fs
@@ -47,6 +47,6 @@ let assertErrorEqual (result: Result<'a, 'b>) (expected: 'b) =
   )
 
 let evaluateAggregator ctx fn args rows =
-  let processor = fun (agg: IAggregator) row -> args |> List.map (Expression.evaluate ctx row) |> agg.Digest
+  let processor = fun (agg: IAggregator) row -> args |> List.map (Expression.evaluate ctx row) |> agg.Transition
   let aggregator = List.fold processor (Aggregator.create ctx fn) rows
-  aggregator.Evaluate ctx
+  aggregator.Final ctx

--- a/src/OpenDiffix.Core/Executor.fs
+++ b/src/OpenDiffix.Core/Executor.fs
@@ -42,14 +42,14 @@ let private executeAggregate context groupingLabels aggregators rowsStream =
         | Some aggregators -> aggregators
         | None -> defaultAggregators
         |> Array.zip aggArgs
-        |> Array.map (fun (args, aggregator) -> args |> List.map argEvaluator |> aggregator.Digest)
+        |> Array.map (fun (args, aggregator) -> args |> List.map argEvaluator |> aggregator.Transition)
 
       Map.add group aggregators state
     )
     initialState
   |> Map.toSeq
   |> Seq.map (fun (group, aggregators) ->
-    let values = aggregators |> Array.map (fun acc -> acc.Evaluate context)
+    let values = aggregators |> Array.map (fun acc -> acc.Final context)
     Array.append group values
   )
 


### PR DESCRIPTION
Just a minor tiny tweak.
Normalize the transition names to those used in Edon's Postgres implementation.