### PR TITLE
Failed to parse spaces after constant string

### DIFF
--- a/src/OpenDiffix.Core/Parser.fs
+++ b/src/OpenDiffix.Core/Parser.fs
@@ -46,7 +46,7 @@ module QueryParser =
     <|> (word "false" |>> fun _ -> Expression.Boolean false)
 
   let stringLiteral =
-    skipChar '\'' >>. manySatisfy (fun c -> c <> '\'') .>> skipChar '\''
+    skipChar '\'' >>. manySatisfy (fun c -> c <> '\'') .>> skipChar '\'' .>> spaces
     |>> Expression.String
 
   let spaceSepUnaliasedExpressions = many1 expr


### PR DESCRIPTION
This resulted in the failure to parse a query that
had any expressions after a string constant.