### PR TITLE
Add absolute lower bound to low count

### DIFF
--- a/queries-sample.json
+++ b/queries-sample.json
@@ -5,6 +5,7 @@
     "anonymization_parameters": {
       "table_settings": {"customers": {"aid_columns":  ["id"]}},
       "seed": 1,
+      "low_count_absolute_lower_bound": 2,
       "low_count_threshold": {
         "lower": 2,
         "upper": 5
@@ -29,6 +30,7 @@
     "anonymization_parameters": {
       "table_settings": {"customers": {"aid_columns":  ["id"]}},
       "seed": 1,
+      "low_count_absolute_lower_bound": 2,
       "low_count_threshold": {
         "lower": 2,
         "upper": 5
@@ -53,6 +55,7 @@
     "anonymization_parameters": {
       "table_settings": {"customers": {"aid_columns":  ["id"]}},
       "seed": 1,
+      "low_count_absolute_lower_bound": 2,
       "low_count_threshold": {
         "lower": 2,
         "upper": 5

--- a/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
@@ -154,6 +154,7 @@ type Tests(db: DBFixture) =
           "purchases", { AidColumns = [ "cid" ] }
         ]
       Seed = 1
+      LowCountAbsoluteLowerBound = 2
       LowCountThreshold = { Threshold.Default with Lower = 5; Upper = 7 }
       OutlierCount = { Lower = 1; Upper = 1 }
       TopCount = { Lower = 1; Upper = 1 }

--- a/src/OpenDiffix.Core.Tests/Anonymizer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Anonymizer.Tests.fs
@@ -23,6 +23,7 @@ let context =
         {
           TableSettings = Map.empty
           Seed = 0
+          LowCountAbsoluteLowerBound = 2
           LowCountThreshold = { Lower = 1; Upper = 1 }
           OutlierCount = { Lower = 1; Upper = 1 }
           TopCount = { Lower = 1; Upper = 1 }

--- a/src/OpenDiffix.Core/Anonymizer.fs
+++ b/src/OpenDiffix.Core/Anonymizer.fs
@@ -35,7 +35,9 @@ let isLowCount (aidSet: Set<AidHash>) (anonymizationParams: AnonymizationParams)
   let rnd = newRandom aidSet anonymizationParams
   let noise = noiseValue rnd anonymizationParams.Noise
   let threshold = randomUniform rnd anonymizationParams.LowCountThreshold
-  aidSet.Count + noise <= threshold
+
+  aidSet.Count < anonymizationParams.LowCountAbsoluteLowerBound
+  || aidSet.Count + noise <= threshold
 
 let count (anonymizationParams: AnonymizationParams) (perUserContribution: Map<AidHash, int64>) =
   let aids = perUserContribution |> Map.toList |> List.map fst |> Set.ofList

--- a/src/OpenDiffix.Core/AnonymizerTypes.fs
+++ b/src/OpenDiffix.Core/AnonymizerTypes.fs
@@ -22,6 +22,7 @@ type AnonymizationParams =
   {
     TableSettings: Map<string, TableSettings>
     Seed: int
+    LowCountAbsoluteLowerBound: int
     LowCountThreshold: Threshold
 
     // Count params
@@ -34,6 +35,7 @@ type AnonymizationParams =
     {
       TableSettings = Map.empty
       Seed = 0
+      LowCountAbsoluteLowerBound = 2
       LowCountThreshold = Threshold.Default
       OutlierCount = Threshold.Default
       TopCount = Threshold.Default


### PR DESCRIPTION
It seems these days are full of low count bug fixes...
We had forgotten to add the absolute low count filter too!
As a result, it was possible for a bucket with only a single user to pass through anonymization!