### PR TITLE
Adapt to Paul's latest LCF design

### DIFF
--- a/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
@@ -154,8 +154,7 @@ type Tests(db: DBFixture) =
           "purchases", { AidColumns = [ "cid" ] }
         ]
       Seed = 1
-      LowCountAbsoluteLowerBound = 2
-      LowCountThreshold = { Threshold.Default with Lower = 5; Upper = 7 }
+      LowCountParams = { Lower = 5.; Mean = 6.; StandardDev = 1. }
       OutlierCount = { Lower = 1; Upper = 1 }
       TopCount = { Lower = 1; Upper = 1 }
       Noise = { StandardDev = 1.; Cutoff = 0. }

--- a/src/OpenDiffix.Core.Tests/Anonymizer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Anonymizer.Tests.fs
@@ -22,8 +22,7 @@ let context =
         {
           TableSettings = Map.empty
           Seed = 0
-          LowCountAbsoluteLowerBound = 2
-          LowCountThreshold = { Lower = 1; Upper = 1 }
+          LowCountParams = { Lower = 1.; StandardDev = 0.; Mean = 1. }
           OutlierCount = { Lower = 1; Upper = 1 }
           TopCount = { Lower = 1; Upper = 1 }
           Noise = { StandardDev = 1.; Cutoff = 0. }

--- a/src/OpenDiffix.Core.Tests/QueryEngine.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/QueryEngine.Tests.fs
@@ -14,8 +14,7 @@ type Tests(db: DBFixture) =
           "customers_small", { AidColumns = [ "id" ] } //
         ]
       Seed = 1
-      LowCountAbsoluteLowerBound = 2
-      LowCountThreshold = { Threshold.Default with Lower = 5; Upper = 7 }
+      LowCountParams = { Lower = 5.; Mean = 6.; StandardDev = 1. }
       OutlierCount = { Lower = 1; Upper = 1 }
       TopCount = { Lower = 1; Upper = 1 }
       Noise = { StandardDev = 1.; Cutoff = 0. }
@@ -66,27 +65,6 @@ type Tests(db: DBFixture) =
       }
 
     let queryResult = runQuery "SELECT city, count(distinct id) FROM customers_small GROUP BY city"
-    assertOkEqual queryResult expected
-
-  [<Fact>]
-  let ``query 7`` () =
-    // This will ensure only the absolute low count filter triggers, since it's less permissive
-    // than the subsequent noisy threshold.
-    let customAnonParams =
-      { anonParams with
-          LowCountAbsoluteLowerBound = 5
-          LowCountThreshold = { Lower = 0; Upper = 0 }
-      }
-
-    let expected =
-      {
-        Columns = [ "city"; "count" ]
-        Rows = [ [| String "Berlin"; Integer 10L |]; [| String "Rome"; Integer 10L |] ]
-      }
-
-    let queryResult =
-      runQueryWithCustomAnonParams customAnonParams "SELECT city, count(distinct id) FROM customers_small GROUP BY city"
-
     assertOkEqual queryResult expected
 
   interface IClassFixture<DBFixture>

--- a/src/OpenDiffix.Core/AnonymizerTypes.fs
+++ b/src/OpenDiffix.Core/AnonymizerTypes.fs
@@ -1,5 +1,14 @@
 namespace OpenDiffix.Core.AnonymizerTypes
 
+type LowCountParams =
+  {
+    Lower: float
+    Mean: float
+    StandardDev: float
+  }
+
+  static member Default = { Lower = 2.; Mean = 4.; StandardDev = 1.8 }
+
 type Threshold =
   {
     Lower: int
@@ -22,8 +31,7 @@ type AnonymizationParams =
   {
     TableSettings: Map<string, TableSettings>
     Seed: int
-    LowCountAbsoluteLowerBound: int
-    LowCountThreshold: Threshold
+    LowCountParams: LowCountParams
 
     // Count params
     OutlierCount: Threshold
@@ -35,8 +43,7 @@ type AnonymizationParams =
     {
       TableSettings = Map.empty
       Seed = 0
-      LowCountAbsoluteLowerBound = 2
-      LowCountThreshold = Threshold.Default
+      LowCountParams = LowCountParams.Default
       OutlierCount = Threshold.Default
       TopCount = Threshold.Default
       Noise = NoiseParam.Default


### PR DESCRIPTION
This LCF more closely matches our previous designs,
where the low count filter is a Gaussian random variable.

Let's wait with this pull, until [Paul's design docs](https://github.com/diffix/reference/pull/80/files#)
have been finalized and merged.

Note: this causes yet another change to our API.
It's also worth considering whether it's worthwhile
having a custom way of specifying the low count filter,
or whether we should specify it like we do regular noise
in terms of standard deviation and cutoff.