### PR TITLE
Generic documentation for noise layers.

### DIFF
--- a/docs/noise-layers.md
+++ b/docs/noise-layers.md
@@ -26,7 +26,7 @@ Most noise layers are seeded with at least the following:
 
 Negative conditions add the symbol `<>` to the seed material. Note that `NOT IN` conditions are converted to their equivalent `<>` forms.
 
-The generic noise layer is seeded only with the secret salt.
+The generic noise layer is seeded with the names of the tables targeted by the query and the secret salt.
 
 ### Clear conditions
 


### PR DESCRIPTION
No matter what will be the final form of LED, we will need to add support for noise layers.
This adds some generic documentation as a starting point, details will be filled in later, when LED design is finalized.