### PR TITLE
Send CLI errors to stderr.

### DIFF
--- a/src/OpenDiffix.CLI/JsonEncodersDecoders.fs
+++ b/src/OpenDiffix.CLI/JsonEncodersDecoders.fs
@@ -70,15 +70,12 @@ let encodeRequestParams query dbPath anonParams =
 let encodeErrorMsg errorMsg =
   Encode.object [ "success", Encode.bool false; "error", Encode.string errorMsg ]
 
-let encodeIndividualQueryResponse (queryRequest: QueryRequest) =
-  function
-  | Ok queryResult ->
-      Encode.object [
-        "success", Encode.bool true
-        "anonymization_parameters", encodeAnonParams queryRequest.AnonymizationParameters
-        "result", encodeQueryResult queryResult
-      ]
-  | Error parseError -> encodeErrorMsg (parseError.ToString())
+let encodeIndividualQueryResponse queryRequest queryResult =
+  Encode.object [
+    "success", Encode.bool true
+    "anonymization_parameters", encodeAnonParams queryRequest.AnonymizationParameters
+    "result", encodeQueryResult queryResult
+  ]
 
 let encodeBatchRunResult (time: System.DateTime) version queryResults =
   Encode.object [

--- a/src/OpenDiffix.CLI/Program.fs
+++ b/src/OpenDiffix.CLI/Program.fs
@@ -56,7 +56,7 @@ let executableName = "OpenDiffix.CLI"
 let parser = ArgumentParser.Create<CliArguments>(programName = executableName)
 
 let failWithUsageInfo errorMsg =
-  failwith $"ERROR: %s{errorMsg}\n\nPlease run '%s{executableName} -h' for help."
+  failwith $"%s{errorMsg}\n\nPlease run '%s{executableName} -h' for help."
 
 let toThreshold =
   function
@@ -131,11 +131,6 @@ let csvFormatter result =
 
 let jsonFormatter = JsonEncodersDecoders.encodeQueryResult >> Thoth.Json.Net.Encode.toString 2
 
-let anonymize formatter query filePath anonParams =
-  match runQuery query filePath anonParams with
-  | Ok result -> formatter result, 0
-  | Error err -> $"ERROR: %s{err}", 1
-
 let batchExecuteQueries (queriesPath: string) =
   if not <| File.Exists queriesPath then
     failWithUsageInfo $"Could not find a queries file at %s{queriesPath}"
@@ -182,12 +177,10 @@ let main argv =
       let filePath = getFilePath parsedArguments
       let anonParams = constructAnonParameters parsedArguments
       let outputFormatter = if parsedArguments.Contains Json then jsonFormatter else csvFormatter
-
-      (anonymize outputFormatter query filePath anonParams)
-      |> fun (output, exitCode) ->
-           printfn $"%s{output}"
-           exitCode
+      let output = runQuery query filePath anonParams |> outputFormatter
+      printfn $"%s{output}"
+      0
 
   with e ->
-    printfn $"%s{e.Message}"
+    eprintfn $"ERROR: %s{e.Message}"
     1

--- a/src/OpenDiffix.Core.Tests/QueryEngine.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/QueryEngine.Tests.fs
@@ -36,7 +36,7 @@ type Tests(db: DBFixture) =
       }
 
     let queryResult = runQuery "SELECT name AS n FROM products WHERE id = 1"
-    assertOkEqual queryResult expected
+    queryResult |> should equal expected
 
   [<Fact>]
   let ``query 2`` () =
@@ -47,7 +47,7 @@ type Tests(db: DBFixture) =
       }
 
     let queryResult = runQuery "SELECT count(*) AS c1, count(DISTINCT length(name)) AS c2 FROM products"
-    assertOkEqual queryResult expected
+    queryResult |> should equal expected
 
   [<Fact>]
   let ``query 3`` () =
@@ -58,7 +58,7 @@ type Tests(db: DBFixture) =
       }
 
     let queryResult = runQuery "SELECT name, SUM(price) FROM products GROUP BY 1 HAVING length(name) = 7"
-    assertOkEqual queryResult expected
+    queryResult |> should equal expected
 
   [<Fact>]
   let ``query 4`` () =
@@ -69,7 +69,7 @@ type Tests(db: DBFixture) =
       }
 
     let queryResult = runQuery "SELECT city, count(distinct id) FROM customers_small GROUP BY city"
-    assertOkEqual queryResult expected
+    queryResult |> should equal expected
 
   [<Fact>]
   let ``query 5 - bucket expansion`` () =
@@ -79,12 +79,11 @@ type Tests(db: DBFixture) =
 
     let expected = { Columns = [ { Name = "city"; Type = StringType } ]; Rows = expectedRows }
 
-    assertOkEqual queryResult expected
+    queryResult |> should equal expected
 
   /// Returns the aggregate result of a query such as `SELECT count(*) FROM ...`
   let runQueryToInteger query =
     runQuery query
-    |> Result.value
     |> fun result ->
          result.Rows
          |> List.head
@@ -138,13 +137,12 @@ type Tests(db: DBFixture) =
         Rows = [ [| String "Water" |] ]
       }
 
-    let queryResult = runQuery "SELECT p.name AS n FROM products AS p WHERE id = 1"
-    assertOkEqual queryResult expected
+    runQuery "SELECT p.name AS n FROM products AS p WHERE id = 1"
 
   let equivalentQueries expectedQuery testQuery =
-    let testResult = runQuery testQuery |> Result.value
-    let expectedResult = runQuery expectedQuery |> Result.value
-    testResult |> should equal expectedResult
+    let testResult = runQuery testQuery
+    let expected = runQuery expectedQuery
+    testResult |> should equal expected
 
   [<Fact>]
   let ``query 11`` () =
@@ -155,7 +153,7 @@ type Tests(db: DBFixture) =
       }
 
     let queryResult = runQuery "SELECT CAST(id AS text) || name AS n FROM products WHERE id = 1"
-    assertOkEqual queryResult expected
+    queryResult |> should equal expected
 
   [<Fact>]
   let ``Subquery wrappers produce consistent results`` () =

--- a/src/OpenDiffix.Core.Tests/TestHelpers.fs
+++ b/src/OpenDiffix.Core.Tests/TestHelpers.fs
@@ -7,34 +7,6 @@ type DBFixture() =
   member this.DataProvider =
     new OpenDiffix.CLI.SQLite.DataProvider(__SOURCE_DIRECTORY__ + "/../../data/data.sqlite") :> IDataProvider
 
-let assertOk (result: Result<'a, 'b>) =
-  Assert.True(
-    match result with
-    | Ok _ -> true
-    | Error _ -> false
-  )
-
-let assertError (result: Result<'a, 'b>) =
-  Assert.True(
-    match result with
-    | Ok _ -> false
-    | Error _ -> true
-  )
-
-let assertOkEqual<'a, 'b> (result: Result<'a, 'b>) (expected: 'a) =
-  match result with
-  | Ok value -> Assert.Equal(expected, value)
-  | Error error -> failwith $"Did not expect error: %A{error}"
-
-let assertErrorEqual (result: Result<'a, 'b>) (expected: 'b) =
-  assertError result
-
-  Assert.True(
-    match result with
-    | Error value when value = expected -> true
-    | _ -> false
-  )
-
 let evaluateAggregator ctx fn args rows =
   let processor = fun (agg: Aggregator.T) row -> args |> List.map (Expression.evaluate ctx row) |> agg.Transition
 

--- a/src/OpenDiffix.Core/QueryEngine.fs
+++ b/src/OpenDiffix.Core/QueryEngine.fs
@@ -18,18 +18,14 @@ let rec private extractColumns query =
 
 type QueryResult = { Columns: Column list; Rows: Row list }
 
-type QueryError = string
+let run context statement : QueryResult =
+  let query =
+    statement
+    |> Parser.parse
+    |> Analyzer.analyze context
+    |> Normalizer.normalize
+    |> Analyzer.rewrite context
 
-let run context statement : Result<QueryResult, QueryError> =
-  try
-    let query =
-      statement
-      |> Parser.parse
-      |> Analyzer.analyze context
-      |> Normalizer.normalize
-      |> Analyzer.rewrite context
-
-    let rows = query |> Planner.plan |> Executor.execute context |> Seq.toList
-    let columns = extractColumns query
-    Ok { Columns = columns; Rows = rows }
-  with ex -> Error ex.Message
+  let rows = query |> Planner.plan |> Executor.execute context |> Seq.toList
+  let columns = extractColumns query
+  { Columns = columns; Rows = rows }


### PR DESCRIPTION
Also drops dry run switch and result usage from query engine.
Closes #192.