### PR TITLE
Support quoted identifiers.

### DIFF
--- a/src/OpenDiffix.Core.Tests/Parser.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Parser.Tests.fs
@@ -394,3 +394,13 @@ let ``Parses star select`` () =
 let ``Parses limit`` () =
   parseFragment selectQuery "SELECT * FROM table LIMIT 10"
   |> should equal (SelectQuery { defaultSelect with Expressions = [ Star ]; Limit = Some(10u) })
+
+[<Fact>]
+let ``Parses quoted indentifier 1`` () =
+  parseFragment selectQuery "SELECT \"*-\\(\" FROM table"
+  |> should equal (SelectQuery { defaultSelect with Expressions = [ As(Identifier(None, "*-\\("), None) ] })
+
+[<Fact>]
+let ``Parses quoted indentifier 2`` () =
+  parseFragment selectQuery "SELECT \"(a)\".\"(b)\" FROM table"
+  |> should equal (SelectQuery { defaultSelect with Expressions = [ As(Identifier(Some "(a)", "(b)"), None) ] })

--- a/src/OpenDiffix.Core/Parser.fs
+++ b/src/OpenDiffix.Core/Parser.fs
@@ -18,8 +18,14 @@ module QueryParser =
 
     many1Satisfy2L isIdentifierFirstChar isIdentifierChar "identifier" .>> spaces
 
+  let quotedIdentifier =
+    let isIdentifierChar token = token <> '"' && token <> '\n'
+    pchar '"' >>. many1SatisfyL isIdentifierChar "quoted identifier" .>> pchar '"'
+
+  let anyIdentifier = simpleIdentifier <|> quotedIdentifier
+
   let identifier =
-    simpleIdentifier .>>. opt (pchar '.' >>. simpleIdentifier)
+    anyIdentifier .>>. opt (pchar '.' >>. anyIdentifier)
     |>> function
     | name, None -> Expression.Identifier(None, name)
     | name1, Some name2 -> Expression.Identifier(Some name1, name2)


### PR DESCRIPTION
This allows referencing columns with weird characters in the name.