### PR TITLE
Stop returning NULL when counting insufficient data.

### DIFF
--- a/src/OpenDiffix.Core.Tests/Anonymizer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Anonymizer.Tests.fs
@@ -106,16 +106,16 @@ let ``anon count(col)`` () =
   |> should equal (Integer 30L)
 
 [<Fact>]
-let ``anon count returns Null if insufficient users`` () =
+let ``anon count returns 0 if insufficient users`` () =
   let firstRow = rows |> List.take 1
 
   firstRow
   |> evaluateAggregator diffixCount [ allAidColumns; strColumn ]
-  |> should equal Null
+  |> should equal (Integer 0L)
 
   firstRow
   |> evaluateAggregator diffixCount [ allAidColumns; aidColumn ]
-  |> should equal Null
+  |> should equal (Integer 0L)
 
 [<Fact>]
 let ``anon count returns 0 for Null inputs`` () =
@@ -126,12 +126,12 @@ let ``anon count returns 0 for Null inputs`` () =
   |> should equal (Integer 0L)
 
 [<Fact>]
-let ``anon count returns Null when all AIDs null`` () =
+let ``anon count returns 0 when all AIDs null`` () =
   let rows = [ 1L .. 10L ] |> List.map (fun _ -> [| Null; String "value"; Null |])
 
   rows
   |> evaluateAggregator diffixCount [ allAidColumns; strColumn ]
-  |> should equal Null
+  |> should equal (Integer 0L)
 
 [<Fact>]
 let ``multi-AID count`` () =
@@ -223,7 +223,7 @@ let ``count distinct with flattening - re-worked example 2 from doc`` () =
   |> should equal (Integer 2L)
 
 [<Fact>]
-let ``counts with insufficient values for one AID return Null`` () =
+let ``counts with insufficient values for one AID return 0`` () =
   let rows =
     [
       // AID1; AID2; Fruit
@@ -241,11 +241,11 @@ let ``counts with insufficient values for one AID return Null`` () =
 
   rows
   |> TestHelpers.evaluateAggregator anonymizedAggregationContext diffixCount [ allAidColumns; value ]
-  |> should equal Null
+  |> should equal (Integer 0L)
 
   rows
   |> TestHelpers.evaluateAggregator anonymizedAggregationContext distinctDiffixCount [ allAidColumns; value ]
-  |> should equal Null
+  |> should equal (Integer 0L)
 
 [<Fact>]
 let ``allows null-values for some of the AID rows`` () =

--- a/src/OpenDiffix.Core.Tests/TestHelpers.fs
+++ b/src/OpenDiffix.Core.Tests/TestHelpers.fs
@@ -10,7 +10,7 @@ type DBFixture() =
 let evaluateAggregator ctx fn args rows =
   let processor = fun (agg: Aggregator.T) row -> args |> List.map (Expression.evaluate ctx row) |> agg.Transition
 
-  let aggregator = List.fold processor (Aggregator.create ctx fn) rows
+  let aggregator = List.fold processor (Aggregator.create ctx true fn) rows
   aggregator.Final ctx
 
 let dummyDataProvider schema =

--- a/src/OpenDiffix.Core/Executor.fs
+++ b/src/OpenDiffix.Core/Executor.fs
@@ -52,7 +52,7 @@ let private executeLimit context (childPlan, amount) : seq<Row> =
 let private executeAggregate context (childPlan, groupingLabels, aggregators) : seq<Row> =
   let groupingLabels = Array.ofList groupingLabels
   let aggFns, aggArgs = aggregators |> Array.ofList |> unpackAggregators
-  let defaultAggregators = aggFns |> Array.map (Aggregator.create context)
+  let defaultAggregators = aggFns |> Array.map (Aggregator.create context (Array.isEmpty groupingLabels))
 
   let initialState : Map<Row, Aggregator.T array> =
     if groupingLabels.Length = 0 then Map [ [||], defaultAggregators ] else Map []


### PR DESCRIPTION
We now return 0 for global counts and `MinAllowedAIDs` for regular buckets counts over insufficient data.

According to https://github.com/diffix/internal-strategy/issues/40#issuecomment-887577344