### PR TITLE
Set PublishTrimmed for projects

### DIFF
--- a/src/OpenDiffix.CLI/OpenDiffix.CLI.fsproj
+++ b/src/OpenDiffix.CLI/OpenDiffix.CLI.fsproj
@@ -4,6 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <Authors>Open Diffix</Authors>
     <Description>CLI interface to the Open Diffix Reference anonymizer</Description>
+    <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />

--- a/src/OpenDiffix.Core/OpenDiffix.Core.fsproj
+++ b/src/OpenDiffix.Core/OpenDiffix.Core.fsproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CommonTypes.fs" />


### PR DESCRIPTION
> PublishTrimmed should be set in the project file so that trim-incompatible features are disabled during dotnet build, but it is also possible to pass these options as dotnet publish arguments