### PR TITLE
Read scanned table's row fields only when they are accessed.

### DIFF
--- a/src/OpenDiffix.Core.Tests/Executor.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Executor.Tests.fs
@@ -29,7 +29,7 @@ type Tests(db: DBFixture) =
   let context = { EvaluationContext.Default with DataProvider = db.DataProvider }
 
   let execute plan =
-    plan |> Executor.execute context |> Seq.toList
+    plan |> Executor.execute context |> Seq.map rowToArray |> Seq.toList
 
   [<Fact>]
   let ``execute scan`` () =
@@ -85,7 +85,7 @@ type Tests(db: DBFixture) =
     let condition = FunctionExpr(ScalarFunction Equals, [ column products 1; Constant(String "xxx") ])
     let plan = Plan.Aggregate(Plan.Filter(Plan.Scan(products), condition), [ nameLength ], [ countStar ])
 
-    let expected : Row list = []
+    let expected : Value array list = []
     plan |> execute |> should equal expected
 
   [<Fact>]

--- a/src/OpenDiffix.Core.Tests/Expression.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Expression.Tests.fs
@@ -445,11 +445,11 @@ module DefaultFunctionsTests =
         Null, String "integer", Null
       ]
 
-let makeRows (ctor1, ctor2, ctor3) (rows: ('a * 'b * 'c) list) : Row list =
+let makeRows (ctor1, ctor2, ctor3) (rows: ('a * 'b * 'c) list) =
   rows |> List.map (fun (a, b, c) -> [| ctor1 a; ctor2 b; ctor3 c |])
 
 let makeRow strValue intValue floatValue =
-  [| String strValue; Integer intValue; Real floatValue |]
+  arrayToRow [| String strValue; Integer intValue; Real floatValue |]
 
 let testRow = makeRow "Some text" 7L 0.25
 
@@ -515,6 +515,7 @@ let sortRows () =
     [| Null; Integer 2L |]
     [| Null; Null |]
   ]
+  |> List.map arrayToRow
   |> Expression.sortRows
        ctx
        [ //
@@ -522,6 +523,7 @@ let sortRows () =
          OrderBy(ColumnReference(1, IntegerType), Descending, NullsFirst)
        ]
   |> List.ofSeq
+  |> List.map rowToArray
   |> should
        equal
        [

--- a/src/OpenDiffix.Core.Tests/TestHelpers.fs
+++ b/src/OpenDiffix.Core.Tests/TestHelpers.fs
@@ -10,7 +10,11 @@ type DBFixture() =
 let evaluateAggregator ctx fn args rows =
   let processor = fun (agg: Aggregator.T) row -> args |> List.map (Expression.evaluate ctx row) |> agg.Transition
 
-  let aggregator = List.fold processor (Aggregator.create ctx true fn) rows
+  let aggregator =
+    rows
+    |> List.map arrayToRow
+    |> List.fold processor (Aggregator.create ctx true fn)
+
   aggregator.Final ctx
 
 let dummyDataProvider schema =

--- a/src/OpenDiffix.Core/CommonTypes.fs
+++ b/src/OpenDiffix.Core/CommonTypes.fs
@@ -16,7 +16,27 @@ type Value =
   | String of string
   | List of Value list
 
-type Row = Value array
+type IRow =
+  abstract Item : int -> Value with get
+  abstract Length : int
+
+type Rows = IRow seq
+
+type ArrayRow(values: Value array) =
+  member this.Values = values
+
+  interface IRow with
+    member this.Item
+      with get (index) = values.[index]
+
+    member this.Length = values.Length
+
+let arrayToRow values = ArrayRow(values) :> IRow
+
+let rowToArray (row: IRow) =
+  match row with
+  | :? ArrayRow as arrayRow -> arrayRow.Values
+  | _ -> Array.init row.Length (fun i -> row.[i])
 
 // ----------------------------------------------------------------
 // Expressions
@@ -110,7 +130,7 @@ type Schema = Table list
 
 type IDataProvider =
   inherit IDisposable
-  abstract OpenTable : table: Table -> Row seq
+  abstract OpenTable : table: Table -> Rows
   abstract GetSchema : unit -> Schema
 
 // ----------------------------------------------------------------

--- a/src/OpenDiffix.Core/Expression.fs
+++ b/src/OpenDiffix.Core/Expression.fs
@@ -167,7 +167,7 @@ let evaluateSetFunction fn args =
   | _ -> failwith $"Invalid usage of set function '%A{fn}'."
 
 /// Evaluates the expression for a given row.
-let rec evaluate (ctx: EvaluationContext) (row: Row) (expr: Expression) =
+let rec evaluate (ctx: EvaluationContext) (row: IRow) (expr: Expression) =
   match expr with
   | FunctionExpr (ScalarFunction fn, args) -> evaluateScalarFunction fn (args |> List.map (evaluate ctx row))
   | FunctionExpr (AggregateFunction (fn, _options), _) -> failwith $"Invalid usage of aggregate function '%A{fn}'."
@@ -177,7 +177,7 @@ let rec evaluate (ctx: EvaluationContext) (row: Row) (expr: Expression) =
   | Constant value -> value
 
 /// Sorts a row sequence based on the given orderings.
-let sortRows ctx orderings (rows: Row seq) =
+let sortRows ctx orderings (rows: Rows) =
   let rec performSort orderings rows =
     match orderings with
     | [] -> rows

--- a/src/OpenDiffix.Core/QueryEngine.fs
+++ b/src/OpenDiffix.Core/QueryEngine.fs
@@ -16,7 +16,7 @@ let rec private extractColumns query =
 // Public API
 // ----------------------------------------------------------------
 
-type QueryResult = { Columns: Column list; Rows: Row list }
+type QueryResult = { Columns: Column list; Rows: Value array list }
 
 let run context statement : QueryResult =
   let query =
@@ -26,6 +26,13 @@ let run context statement : QueryResult =
     |> Normalizer.normalize
     |> Analyzer.rewrite context
 
-  let rows = query |> Planner.plan |> Executor.execute context |> Seq.toList
   let columns = extractColumns query
+
+  let rows =
+    query
+    |> Planner.plan
+    |> Executor.execute context
+    |> Seq.map rowToArray
+    |> Seq.toList
+
   { Columns = columns; Rows = rows }


### PR DESCRIPTION
This implements your proposed optimization of reading the row fields only when they are required.

It results in ~10% performance improvement (from 1174 ms down to 1056 ms) for Easy Diffix anonymization preview calls.
Not great, but not terrible either 🙂.

