### PR TITLE
Support generalized `round/floor/ceil` functions.

### DIFF
--- a/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
@@ -423,12 +423,12 @@ type Tests(db: DBFixture) =
 
   [<Fact>]
   let ``SQL seed from column generalization`` () =
-    assertSqlSeed "SELECT substring(city, 1, 2) FROM customers_small" "substring,customers_small.city,1,2"
+    assertSqlSeed "SELECT substring(city, 1, 2) FROM customers_small" "range,customers_small.city,1,2"
 
   [<Fact>]
   let ``SQL seed from multiple groupings from multiple tables`` () =
     assertSqlSeed
       "SELECT count(*) FROM customers_small JOIN purchases ON id = cid GROUP BY city, round(amount)"
-      "customers_small.city,round,purchases.amount"
+      "customers_small.city,range,purchases.amount"
 
   interface IClassFixture<DBFixture>

--- a/src/OpenDiffix.Core.Tests/Expression.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Expression.Tests.fs
@@ -272,8 +272,18 @@ module DefaultFunctionsTests =
         Null, Null
       ]
 
-    runsBinary
+    fails
       Round
+      [ //
+        [ Integer 5L ]
+        [ Boolean true ]
+        [ String "a" ]
+      ]
+
+  [<Fact>]
+  let RoundBy () =
+    runsBinary
+      RoundBy
       [
         Integer 3L, Integer 2L, Integer 4L
         Integer 3L, Real 2.5, Real 2.5
@@ -285,11 +295,8 @@ module DefaultFunctionsTests =
       ]
 
     fails
-      Round
+      RoundBy
       [ //
-        [ Integer 5L ]
-        [ Boolean true ]
-        [ String "a" ]
         [ Integer 5L; String "a" ]
         [ String "a"; Real 1.0 ]
       ]
@@ -306,8 +313,18 @@ module DefaultFunctionsTests =
         Null, Null
       ]
 
-    runsBinary
+    fails
       Ceil
+      [ //
+        [ Integer 5L ]
+        [ Boolean true ]
+        [ String "a" ]
+      ]
+
+  [<Fact>]
+  let CeilBy () =
+    runsBinary
+      CeilBy
       [
         Integer 3L, Integer 2L, Integer 4L
         Integer 3L, Real 2.5, Real 5.0
@@ -319,11 +336,8 @@ module DefaultFunctionsTests =
       ]
 
     fails
-      Ceil
+      CeilBy
       [ //
-        [ Integer 5L ]
-        [ Boolean true ]
-        [ String "a" ]
         [ Integer 5L; String "a" ]
         [ String "a"; Real 1.0 ]
       ]
@@ -340,8 +354,18 @@ module DefaultFunctionsTests =
         Null, Null
       ]
 
-    runsBinary
+    fails
       Floor
+      [ //
+        [ Integer 5L ]
+        [ Boolean true ]
+        [ String "a" ]
+      ]
+
+  [<Fact>]
+  let FloorbY () =
+    runsBinary
+      FloorBy
       [
         Integer 3L, Integer 2L, Integer 2L
         Integer 3L, Real 2.5, Real 2.5
@@ -353,11 +377,8 @@ module DefaultFunctionsTests =
       ]
 
     fails
-      Floor
+      FloorBy
       [ //
-        [ Integer 5L ]
-        [ Boolean true ]
-        [ String "a" ]
         [ Integer 5L; String "a" ]
         [ String "a"; Real 1.0 ]
       ]

--- a/src/OpenDiffix.Core.Tests/QueryEngine.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/QueryEngine.Tests.fs
@@ -168,11 +168,11 @@ type Tests(db: DBFixture) =
 
   [<Fact>]
   let ``query 12 - group with rounding`` () =
-    let queryResult = runQuery "SELECT round(age, 5), count(*) FROM customers_small GROUP BY 1"
+    let queryResult = runQuery "SELECT round_by(age, 5), count(*) FROM customers_small GROUP BY 1"
 
     let expected =
       {
-        Columns = [ { Name = "round"; Type = IntegerType }; { Name = "count"; Type = IntegerType } ]
+        Columns = [ { Name = "round_by"; Type = IntegerType }; { Name = "count"; Type = IntegerType } ]
         Rows = [ [| Integer 25L; Integer 7L |]; [| Integer 30L; Integer 7L |]; [| Integer 35L; Integer 6L |] ]
       }
 

--- a/src/OpenDiffix.Core/Analyzer.fs
+++ b/src/OpenDiffix.Core/Analyzer.fs
@@ -321,10 +321,16 @@ let rec private basicSeedMaterial rangeColumns expression =
 
 let private functionSeedMaterial =
   function
-  | Substring -> "substring"
-  | Ceil -> "ceil"
-  | Floor -> "floor"
-  | Round -> "round"
+  | Substring
+  | Ceil
+  | Floor
+  | Round
+  | Ceil
+  | Floor
+  | Round
+  | CeilBy
+  | FloorBy
+  | RoundBy -> "range"
   | WidthBucket -> "width_bucket"
   | Concat -> "concat"
   | _ -> failwith "Unsupported function used for defining buckets."

--- a/src/OpenDiffix.Core/CommonTypes.fs
+++ b/src/OpenDiffix.Core/CommonTypes.fs
@@ -59,6 +59,9 @@ type ScalarFunction =
   | Round
   | Floor
   | Ceil
+  | RoundBy
+  | FloorBy
+  | CeilBy
   | Abs
   | Length
   | Lower

--- a/src/OpenDiffix.Core/Expression.fs
+++ b/src/OpenDiffix.Core/Expression.fs
@@ -33,11 +33,10 @@ let typeOfScalarFunction fn args =
   | Length -> IntegerType
   | Round
   | Floor
-  | Ceil ->
-    match args with
-    | [ _ ] -> IntegerType
-    | [ _; amount ] -> typeOf amount
-    | _ -> failwith $"Invalid arguments supplied to function `#{fn}`."
+  | Ceil -> IntegerType
+  | RoundBy
+  | FloorBy
+  | CeilBy -> args |> List.item 1 |> typeOf
   | Abs -> args |> List.exactlyOne |> typeOf
   | Lower
   | Upper
@@ -109,28 +108,30 @@ let rec evaluateScalarFunction fn args =
   | Or, [ Boolean b1; Boolean b2 ] -> Boolean(b1 || b2)
 
   | Round, [ Real r ] -> r |> round |> int64 |> Integer
-  | Round, [ _; Integer amount ] when amount <= 0L -> Null
-  | Round, [ _; Real amount ] when amount <= 0.0 -> Null
-  | Round, [ Integer value; Integer amount ] -> (float value / float amount) |> round |> int64 |> (*) amount |> Integer
-  | Round, [ Integer value; Real amount ] -> (float value / amount) |> round |> (*) amount |> Real
-  | Round, [ Real value; Integer amount ] -> (value / float amount) |> round |> int64 |> (*) amount |> Integer
-  | Round, [ Real value; Real amount ] -> (value / amount) |> round |> (*) amount |> Real
+  | RoundBy, [ _; Integer amount ] when amount <= 0L -> Null
+  | RoundBy, [ _; Real amount ] when amount <= 0.0 -> Null
+  | RoundBy, [ Integer value; Integer amount ] ->
+    (float value / float amount) |> round |> int64 |> (*) amount |> Integer
+  | RoundBy, [ Integer value; Real amount ] -> (float value / amount) |> round |> (*) amount |> Real
+  | RoundBy, [ Real value; Integer amount ] -> (value / float amount) |> round |> int64 |> (*) amount |> Integer
+  | RoundBy, [ Real value; Real amount ] -> (value / amount) |> round |> (*) amount |> Real
 
   | Ceil, [ Real r ] -> r |> ceil |> int64 |> Integer
-  | Ceil, [ _; Integer amount ] when amount <= 0L -> Null
-  | Ceil, [ _; Real amount ] when amount <= 0.0 -> Null
-  | Ceil, [ Integer value; Integer amount ] -> (float value / float amount) |> ceil |> int64 |> (*) amount |> Integer
-  | Ceil, [ Integer value; Real amount ] -> (float value / amount) |> ceil |> (*) amount |> Real
-  | Ceil, [ Real value; Integer amount ] -> (value / float amount) |> ceil |> int64 |> (*) amount |> Integer
-  | Ceil, [ Real value; Real amount ] -> (value / amount) |> ceil |> (*) amount |> Real
+  | CeilBy, [ _; Integer amount ] when amount <= 0L -> Null
+  | CeilBy, [ _; Real amount ] when amount <= 0.0 -> Null
+  | CeilBy, [ Integer value; Integer amount ] -> (float value / float amount) |> ceil |> int64 |> (*) amount |> Integer
+  | CeilBy, [ Integer value; Real amount ] -> (float value / amount) |> ceil |> (*) amount |> Real
+  | CeilBy, [ Real value; Integer amount ] -> (value / float amount) |> ceil |> int64 |> (*) amount |> Integer
+  | CeilBy, [ Real value; Real amount ] -> (value / amount) |> ceil |> (*) amount |> Real
 
   | Floor, [ Real r ] -> r |> floor |> int64 |> Integer
-  | Floor, [ _; Integer amount ] when amount <= 0L -> Null
-  | Floor, [ _; Real amount ] when amount <= 0.0 -> Null
-  | Floor, [ Integer value; Integer amount ] -> (float value / float amount) |> floor |> int64 |> (*) amount |> Integer
-  | Floor, [ Integer value; Real amount ] -> (float value / amount) |> floor |> (*) amount |> Real
-  | Floor, [ Real value; Integer amount ] -> (value / float amount) |> floor |> int64 |> (*) amount |> Integer
-  | Floor, [ Real value; Real amount ] -> (value / amount) |> floor |> (*) amount |> Real
+  | FloorBy, [ _; Integer amount ] when amount <= 0L -> Null
+  | FloorBy, [ _; Real amount ] when amount <= 0.0 -> Null
+  | FloorBy, [ Integer value; Integer amount ] ->
+    (float value / float amount) |> floor |> int64 |> (*) amount |> Integer
+  | FloorBy, [ Integer value; Real amount ] -> (float value / amount) |> floor |> (*) amount |> Real
+  | FloorBy, [ Real value; Integer amount ] -> (value / float amount) |> floor |> int64 |> (*) amount |> Integer
+  | FloorBy, [ Real value; Real amount ] -> (value / amount) |> floor |> (*) amount |> Real
 
   | Abs, [ Real r ] -> r |> abs |> Real
   | Abs, [ Integer i ] -> i |> abs |> Integer

--- a/src/OpenDiffix.Core/Utils.fs
+++ b/src/OpenDiffix.Core/Utils.fs
@@ -54,6 +54,9 @@ module Function =
     | "round" -> ScalarFunction Round
     | "ceil" -> ScalarFunction Ceil
     | "floor" -> ScalarFunction Floor
+    | "round_by" -> ScalarFunction RoundBy
+    | "ceil_by" -> ScalarFunction CeilBy
+    | "floor_by" -> ScalarFunction FloorBy
     | "abs" -> ScalarFunction Abs
     | "length" -> ScalarFunction Length
     | "lower" -> ScalarFunction Lower


### PR DESCRIPTION
This is needed for building the SQL noise layer when using generalization in Easy Diffix.