### PR TITLE
Support vanilla SQL in the CLI, when no columns are selected

### DIFF
--- a/src/OpenDiffix.CLI/SQLiteDataProvider.fs
+++ b/src/OpenDiffix.CLI/SQLiteDataProvider.fs
@@ -84,10 +84,14 @@ type DataProvider(dbPath: string) =
       )
 
     member this.OpenTable(table, columnIndices) =
+
       let columns =
-        columnIndices
-        |> List.map (fun index -> $"\"%s{table.Columns.[index].Name}\"")
-        |> String.join ", "
+        if columnIndices.IsEmpty then
+          "1"
+        else
+          columnIndices
+          |> List.map (fun index -> $"\"%s{table.Columns.[index].Name}\"")
+          |> String.join ", "
 
       let loadQuery = $"SELECT {columns} FROM {table.Name}"
 


### PR DESCRIPTION
This makes the following work:

```
dotnet run --project src/OpenDiffix.CLI/ -- -f data/data.sqlite --aid-columns customers.id -q "SELECT count(*) FROM purchases"
```

previously it would return:

```
ERROR: SQL logic error
near "FROM": syntax error
```

because it would try to `SELECT   FROM purchases`, as the underlying SQLite query has no columns specified.