### PR TITLE
Experiment: boost count distinct performance staying functional

### DIFF
--- a/src/OpenDiffix.Core/Anonymizer.fs
+++ b/src/OpenDiffix.Core/Anonymizer.fs
@@ -171,15 +171,21 @@ let private transposeToPerAid (aidsPerValue: KeyValuePair<Value, HashSet<AidHash
 
   result
 
-let rec private distributeValues valuesByAID =
+
+let rec private distributeValuesAcc valuesByAID acc =
   match valuesByAID with
-  | [] -> [] // Done :D
-  | (_aid, []) :: restValuesByAID -> distributeValues restValuesByAID
+  | [] -> acc // Done :D
+  | (_aid, []) :: restValuesByAID -> distributeValuesAcc restValuesByAID acc
   | (aid, value :: restValues) :: restValuesByAID ->
     let restValuesByAID = // Drop current value from the remaining items.
       List.map (fun (aid, values) -> aid, values |> List.filter ((<>) value)) restValuesByAID
 
-    (aid, value) :: distributeValues (restValuesByAID @ [ aid, restValues ])
+    let new_acc = (aid, value) :: acc
+    // distributeValuesAcc (restValuesByAID @ [ aid, restValues ]) new_acc
+    distributeValuesAcc ((aid, restValues) :: restValuesByAID) new_acc
+
+
+let rec private distributeValues valuesByAID = distributeValuesAcc valuesByAID []
 
 let private countDistinctFlatteningByAid
   (executionContext: ExecutionContext)

--- a/src/OpenDiffix.Core/Anonymizer.fs
+++ b/src/OpenDiffix.Core/Anonymizer.fs
@@ -172,20 +172,23 @@ let private transposeToPerAid (aidsPerValue: KeyValuePair<Value, HashSet<AidHash
   result
 
 
-let rec private distributeValuesAcc valuesByAID acc =
+let rec private distributeValuesAcc valuesByAID valuesByAID2 acc (usedSet: Set<Value>) =
   match valuesByAID with
-  | [] -> acc // Done :D
-  | (_aid, []) :: restValuesByAID -> distributeValuesAcc restValuesByAID acc
+  | [] ->
+    match valuesByAID2 with
+    | [] -> acc // Done :D
+    | newValuesByAID -> distributeValuesAcc (List.rev newValuesByAID) [] acc usedSet
+  | (_aid, []) :: restValuesByAID -> distributeValuesAcc restValuesByAID valuesByAID2 acc usedSet
   | (aid, value :: restValues) :: restValuesByAID ->
-    let restValuesByAID = // Drop current value from the remaining items.
-      List.map (fun (aid, values) -> aid, values |> List.filter ((<>) value)) restValuesByAID
+    if (Set.contains value usedSet) then
+      distributeValuesAcc ((aid, restValues) :: restValuesByAID) valuesByAID2 acc usedSet
+    else
+      let new_acc = (aid, value) :: acc
+      // distributeValuesAcc (restValuesByAID @ [ aid, restValues ]) new_acc
+      distributeValuesAcc restValuesByAID ((aid, restValues) :: valuesByAID2) new_acc (usedSet.Add value)
 
-    let new_acc = (aid, value) :: acc
-    // distributeValuesAcc (restValuesByAID @ [ aid, restValues ]) new_acc
-    distributeValuesAcc ((aid, restValues) :: restValuesByAID) new_acc
-
-
-let rec private distributeValues valuesByAID = distributeValuesAcc valuesByAID []
+let rec private distributeValues valuesByAID =
+  distributeValuesAcc valuesByAID [] [] (Set.empty)
 
 let private countDistinctFlatteningByAid
   (executionContext: ExecutionContext)

--- a/src/OpenDiffix.Core/Anonymizer.fs
+++ b/src/OpenDiffix.Core/Anonymizer.fs
@@ -183,9 +183,9 @@ let rec private distributeValuesAcc valuesByAID valuesByAID2 acc (usedSet: Set<V
     if (Set.contains value usedSet) then
       distributeValuesAcc ((aid, restValues) :: restValuesByAID) valuesByAID2 acc usedSet
     else
-      let new_acc = (aid, value) :: acc
-      // distributeValuesAcc (restValuesByAID @ [ aid, restValues ]) new_acc
-      distributeValuesAcc restValuesByAID ((aid, restValues) :: valuesByAID2) new_acc (usedSet.Add value)
+      let newAcc = (aid, value) :: acc
+      let newUsedSet = usedSet.Add value
+      distributeValuesAcc restValuesByAID ((aid, restValues) :: valuesByAID2) newAcc newUsedSet
 
 let rec private distributeValues valuesByAID =
   distributeValuesAcc valuesByAID [] [] (Set.empty)


### PR DESCRIPTION
There are 3 optimizations stacked here, but it might be up to only one of them:
1/ use the "accumulator as argument" pattern for the recursion (didn't seem to help at all on first interation)
2/ avoid appending by the prepend and reverse trick with `valuesByAID2` (2x speedup)
3/ avoid `List.filter ((<>) value))` by offloading the "taken" `values` to a Set passed along (20x speedup, on par with imperative)

This is still quite dirty, as I struggled to get past F# syntax. At the minimum we need to check if 1 or 2 matter at all, given 3