### PR TITLE
Tidy JsonEncodersDecoders using Encode.Auto

### DIFF
--- a/src/OpenDiffix.CLI/AssemblyInfo.fs
+++ b/src/OpenDiffix.CLI/AssemblyInfo.fs
@@ -28,20 +28,18 @@ open System.Reflection
 
 do ()
 
-open Thoth.Json.Net
+let version =
+  let semVerString =
+    sprintf "%s.%s.%s" ThisAssembly.Git.SemVer.Major ThisAssembly.Git.SemVer.Minor ThisAssembly.Git.SemVer.Patch
 
-let versionJsonValue =
-  Encode.object [
-    "name", Encode.string "OpenDiffix Reference implementation"
-    "version",
-    Encode.object [
-      "version",
-      Encode.string (
-        sprintf "%s.%s.%s" ThisAssembly.Git.SemVer.Major ThisAssembly.Git.SemVer.Minor ThisAssembly.Git.SemVer.Patch
-      )
-      "commit_number", Encode.int (int ThisAssembly.Git.Commits)
-      "branch", Encode.string ThisAssembly.Git.Branch
-      "sha", Encode.string ThisAssembly.Git.Commit
-      "dirty_build", Encode.bool ThisAssembly.Git.IsDirty
-    ]
-  ]
+  {|
+    Name = "OpenDiffix Reference implementation"
+    Version =
+      {|
+        Version = semVerString
+        CommitNumber = (int ThisAssembly.Git.Commits)
+        Branch = ThisAssembly.Git.Branch
+        Sha = ThisAssembly.Git.Commit
+        DirtyBuild = ThisAssembly.Git.IsDirty
+      |}
+  |}


### PR DESCRIPTION
Closes #246. Supersedes #269, see prior discussion there for background.

This version:
1/ gets rid of Encode.object in favor of Encode.Auto
2/ leverages anonymous records to describe the JSON schema for encoded responses and to do transformations between domain and JSON objects
3/ does some additional cleanups
4/ gets rid of the Thoth.JSON.Net internals leaking into the `Program.fs` file
