### PR TITLE
ORDER BY parser and analyzer

### DIFF
--- a/src/OpenDiffix.Core.Tests/Parser.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Parser.Tests.fs
@@ -265,6 +265,7 @@ let ``Parse complex aggregate query`` () =
        GROUP BY col1
        HAVING count(distinct aid) > 1
        ORDER BY col2
+       LIMIT 42
        """
   |> should
        equal
@@ -284,6 +285,7 @@ let ``Parse complex aggregate query`` () =
            GroupBy = [ Identifier(None, "col1") ]
            Having = Some <| Gt(Function("count", [ Distinct(Identifier(None, "aid")) ]), Integer 1L)
            OrderBy = [ Identifier(None, "col2") ]
+           Limit = Some(42u)
        }
 
 [<Fact>]

--- a/src/OpenDiffix.Core.Tests/Parser.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Parser.Tests.fs
@@ -187,13 +187,13 @@ let ``Parses ORDER BY statement`` () =
   |> should
        equal
        [
-         OrderSpec(Identifier(None, "a"), None, None)
-         OrderSpec(Identifier(None, "b"), None, None)
-         OrderSpec(Identifier(None, "c"), None, None)
+         OrderSpec(Identifier(None, "a"), Asc, NullsLast)
+         OrderSpec(Identifier(None, "b"), Asc, NullsLast)
+         OrderSpec(Identifier(None, "c"), Asc, NullsLast)
        ]
 
   parseFragment orderBy "ORDER BY a"
-  |> should equal [ OrderSpec(Identifier(None, "a"), None, None) ]
+  |> should equal [ OrderSpec(Identifier(None, "a"), Asc, NullsLast) ]
 
   expectFailWithParser orderBy "ORDER BY"
 
@@ -296,7 +296,7 @@ let ``Parse complex aggregate query`` () =
              )
            GroupBy = [ Identifier(None, "col1") ]
            Having = Some <| Gt(Function("count", [ Distinct(Identifier(None, "aid")) ]), Integer 1L)
-           OrderBy = [ OrderSpec(Identifier(None, "col2"), Some(Desc), Some(NullsFirst)) ]
+           OrderBy = [ OrderSpec(Identifier(None, "col2"), Desc, NullsFirst) ]
            Limit = Some(42u)
        }
 

--- a/src/OpenDiffix.Core.Tests/Parser.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Parser.Tests.fs
@@ -17,6 +17,7 @@ let defaultSelect =
     GroupBy = []
     Having = None
     Limit = None
+    OrderBy = []
   }
 
 let expectFail query =
@@ -181,6 +182,15 @@ let ``Parses GROUP BY statement`` () =
   expectFailWithParser groupBy "GROUP BY"
 
 [<Fact>]
+let ``Parses ORDER BY statement`` () =
+  parseFragment orderBy "ORDER BY a, b, c"
+  |> should equal [ Identifier(None, "a"); Identifier(None, "b"); Identifier(None, "c") ]
+
+  parseFragment orderBy "ORDER BY a" |> should equal [ Identifier(None, "a") ]
+
+  expectFailWithParser orderBy "ORDER BY"
+
+[<Fact>]
 let ``Parses SELECT by itself`` () =
   parseFragment selectQuery "SELECT col FROM table"
   |> should equal (SelectQuery { defaultSelect with Expressions = [ As(Identifier(None, "col"), None) ] })
@@ -254,6 +264,7 @@ let ``Parse complex aggregate query`` () =
        WHERE col1 = 1 AND col2 = 2 or col2 = 3
        GROUP BY col1
        HAVING count(distinct aid) > 1
+       ORDER BY col2
        """
   |> should
        equal
@@ -272,6 +283,7 @@ let ``Parse complex aggregate query`` () =
              )
            GroupBy = [ Identifier(None, "col1") ]
            Having = Some <| Gt(Function("count", [ Distinct(Identifier(None, "aid")) ]), Integer 1L)
+           OrderBy = [ Identifier(None, "col2") ]
        }
 
 [<Fact>]

--- a/src/OpenDiffix.Core.Tests/QueryEngine.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/QueryEngine.Tests.fs
@@ -180,6 +180,18 @@ type Tests(db: DBFixture) =
     queryResult |> should equal expected
 
   [<Fact>]
+  let ``query 13 - order by`` () =
+    let queryResult = runQuery "SELECT age, count(*) FROM customers_small GROUP BY 1 ORDER BY 1"
+
+    let expected =
+      {
+        Columns = [ { Name = "age"; Type = IntegerType }; { Name = "count"; Type = IntegerType } ]
+        Rows = [ [| Integer 25L; Integer 7L |]; [| Integer 30L; Integer 7L |]; [| Integer 35L; Integer 6L |] ]
+      }
+
+    queryResult |> should equal expected
+
+  [<Fact>]
   let ``Subquery wrappers produce consistent results`` () =
     equivalentQueries
       "SELECT p.name AS n FROM products AS p WHERE id = 1"

--- a/src/OpenDiffix.Core/Analyzer.fs
+++ b/src/OpenDiffix.Core/Analyzer.fs
@@ -142,6 +142,39 @@ let private mapOrderByIndices (targetList: TargetEntry list) orderByExpressions 
   let selectedExpressions = targetList |> List.map (fun targetEntry -> targetEntry.Expression)
   orderByExpressions |> List.map (mapOrderByIndex selectedExpressions)
 
+let private interpretDirection optDirection =
+  optDirection
+  |> Option.map (
+    function
+    | ParserTypes.Asc -> Ascending
+    | ParserTypes.Desc -> Descending
+    | _ -> failwith "Invalid `ORDER BY` clause"
+  )
+
+let private interpretNullsBehavior optNullsBehavior =
+  optNullsBehavior
+  |> Option.map (
+    function
+    | ParserTypes.NullsFirst -> NullsFirst
+    | ParserTypes.NullsLast -> NullsLast
+    | _ -> failwith "Invalid `ORDER BY` clause"
+  )
+
+let private interpretOrderByExpression rangeColumns expression =
+  match expression with
+  | ParserTypes.OrderSpec (expression, optDirection, optNullsBehavior) ->
+    let (direction, nullsBehavior) =
+      // we want the default nulls behavior to be "NULL values are largest", `ORDER BY x DESC` is a special case
+      match (interpretDirection optDirection, interpretNullsBehavior optNullsBehavior) with
+      | None, None -> Ascending, NullsLast
+      | Some Ascending, None -> Ascending, NullsLast
+      | Some Descending, None -> Descending, NullsFirst
+      | None, Some nullsBehavior -> Ascending, nullsBehavior
+      | Some direction, Some nullsBehavior -> direction, nullsBehavior
+
+    (mapExpression rangeColumns expression), direction, nullsBehavior
+  | _ -> failwith "Invalid `ORDER BY` clause"
+
 // ----------------------------------------------------------------
 // Query range
 // ----------------------------------------------------------------
@@ -223,18 +256,9 @@ let private mapQuery schema anonParams isSubQuery (selectQuery: ParserTypes.Sele
 
   let simpleOrderBy =
     selectQuery.OrderBy
-    |> List.map (fun expression ->
-      // FIXME dat warning
-      match expression with
-      | ParserTypes.OrderSpec (expression, b, c) ->
-        OrderBy(
-          // FIXME: what is this?
-          mapExpression rangeColumns expression,
-          // FIXME think about our defaults here
-          (if b = Some(ParserTypes.Asc) then Ascending else Descending),
-          (if c = Some(ParserTypes.NullsFirst) then NullsFirst else NullsLast)
-        )
-    )
+    |> List.map (interpretOrderByExpression rangeColumns)
+    |> mapOrderByIndices targetList
+    |> List.map (fun (expression, direction, nullsBehavior) -> OrderBy(expression, direction, nullsBehavior))
 
   let isAggregating = not (List.isEmpty groupBy && List.isEmpty (collectAggregates targetList))
 

--- a/src/OpenDiffix.Core/Analyzer.fs
+++ b/src/OpenDiffix.Core/Analyzer.fs
@@ -204,6 +204,13 @@ let private mapQuery schema anonParams isSubQuery (selectQuery: ParserTypes.Sele
     |> List.map (mapExpression rangeColumns)
     |> mapGroupByIndices targetList
 
+  let simpleOrderBy =
+    selectQuery.OrderBy
+    // FIXME: what is this?
+    |> List.map (mapExpression rangeColumns)
+    // FIXME: why this wrapping here?
+    |> List.map (fun expression -> OrderBy(expression, Ascending, NullsFirst))
+
   let isAggregating = not (List.isEmpty groupBy && List.isEmpty (collectAggregates targetList))
 
   let aidTargets =
@@ -235,7 +242,7 @@ let private mapQuery schema anonParams isSubQuery (selectQuery: ParserTypes.Sele
     From = range
     GroupBy = groupBy
     Having = havingClause
-    OrderBy = []
+    OrderBy = simpleOrderBy
     Limit = selectQuery.Limit
   }
 

--- a/src/OpenDiffix.Core/Analyzer.fs
+++ b/src/OpenDiffix.Core/Analyzer.fs
@@ -142,37 +142,22 @@ let private mapOrderByIndices (targetList: TargetEntry list) orderByExpressions 
   let selectedExpressions = targetList |> List.map (fun targetEntry -> targetEntry.Expression)
   orderByExpressions |> List.map (mapOrderByIndex selectedExpressions)
 
-let private interpretDirection optDirection =
-  optDirection
-  |> Option.map (
-    function
-    | ParserTypes.Asc -> Ascending
-    | ParserTypes.Desc -> Descending
-    | _ -> failwith "Invalid `ORDER BY` clause"
-  )
+let private interpretDirection direction =
+  match direction with
+  | ParserTypes.Asc -> Ascending
+  | ParserTypes.Desc -> Descending
+  | _ -> failwith "Invalid `ORDER BY` clause"
 
-let private interpretNullsBehavior optNullsBehavior =
-  optNullsBehavior
-  |> Option.map (
-    function
-    | ParserTypes.NullsFirst -> NullsFirst
-    | ParserTypes.NullsLast -> NullsLast
-    | _ -> failwith "Invalid `ORDER BY` clause"
-  )
+let private interpretNullsBehavior nullsBehavior =
+  match nullsBehavior with
+  | ParserTypes.NullsFirst -> NullsFirst
+  | ParserTypes.NullsLast -> NullsLast
+  | _ -> failwith "Invalid `ORDER BY` clause"
 
 let private interpretOrderByExpression rangeColumns expression =
   match expression with
-  | ParserTypes.OrderSpec (expression, optDirection, optNullsBehavior) ->
-    let (direction, nullsBehavior) =
-      // we want the default nulls behavior to be "NULL values are largest", `ORDER BY x DESC` is a special case
-      match (interpretDirection optDirection, interpretNullsBehavior optNullsBehavior) with
-      | None, None -> Ascending, NullsLast
-      | Some Ascending, None -> Ascending, NullsLast
-      | Some Descending, None -> Descending, NullsFirst
-      | None, Some nullsBehavior -> Ascending, nullsBehavior
-      | Some direction, Some nullsBehavior -> direction, nullsBehavior
-
-    (mapExpression rangeColumns expression), direction, nullsBehavior
+  | ParserTypes.OrderSpec (expression, direction, nullsBehavior) ->
+    (mapExpression rangeColumns expression), (interpretDirection direction), (interpretNullsBehavior nullsBehavior)
   | _ -> failwith "Invalid `ORDER BY` clause"
 
 // ----------------------------------------------------------------

--- a/src/OpenDiffix.Core/Parser.fs
+++ b/src/OpenDiffix.Core/Parser.fs
@@ -91,6 +91,8 @@ module QueryParser =
 
   let limitClause = word "LIMIT" >>. puint32
 
+  let orderBy = words [ "ORDER"; "BY" ] .>> spaces >>. commaSeparated expr
+
   let groupBy = words [ "GROUP"; "BY" ] .>> spaces >>. commaSeparated expr
 
   let distinct = opt (word "distinct") |>> Option.isSome
@@ -147,18 +149,21 @@ module QueryParser =
                                            >>= fun having ->
                                                  opt limitClause
                                                  >>= fun limit ->
-                                                       let query =
-                                                         {
-                                                           SelectDistinct = distinct
-                                                           Expressions = columns
-                                                           From = from
-                                                           Where = whereClause
-                                                           GroupBy = groupBy |> Option.defaultValue []
-                                                           Having = having
-                                                           Limit = limit
-                                                         }
+                                                       opt orderBy
+                                                       >>= fun orderBy ->
+                                                             let query =
+                                                               {
+                                                                 SelectDistinct = distinct
+                                                                 Expressions = columns
+                                                                 From = from
+                                                                 Where = whereClause
+                                                                 GroupBy = groupBy |> Option.defaultValue []
+                                                                 Having = having
+                                                                 Limit = limit
+                                                                 OrderBy = orderBy |> Option.defaultValue []
+                                                               }
 
-                                                       preturn (Expression.SelectQuery query)
+                                                             preturn (Expression.SelectQuery query)
 
   // This is sort of silly... but the operator precedence parser is case sensitive. This means
   // if we add a parser for AND, then it will fail if you write a query as And... Therefore

--- a/src/OpenDiffix.Core/Parser.fs
+++ b/src/OpenDiffix.Core/Parser.fs
@@ -147,10 +147,10 @@ module QueryParser =
                                      >>= fun groupBy ->
                                            opt havingClause
                                            >>= fun having ->
-                                                 opt limitClause
-                                                 >>= fun limit ->
-                                                       opt orderBy
-                                                       >>= fun orderBy ->
+                                                 opt orderBy
+                                                 >>= fun orderBy ->
+                                                       opt limitClause
+                                                       >>= fun limit ->
                                                              let query =
                                                                {
                                                                  SelectDistinct = distinct

--- a/src/OpenDiffix.Core/Parser.fs
+++ b/src/OpenDiffix.Core/Parser.fs
@@ -44,6 +44,10 @@ module QueryParser =
   let commaSeparated p = sepBy1 p (pchar ',' .>> spaces)
 
   let star = word "*" |>> fun _ -> Expression.Star
+  let asc = word "ASC" |>> fun _ -> Expression.Asc
+  let desc = word "DESC" |>> fun _ -> Expression.Desc
+  let nullsFirst = word "NULLS FIRST" |>> fun _ -> Expression.NullsFirst
+  let nullsLast = word "NULLS LAST" |>> fun _ -> Expression.NullsLast
 
   let alias = word "AS" >>. identifier
 
@@ -91,7 +95,11 @@ module QueryParser =
 
   let limitClause = word "LIMIT" >>. puint32
 
-  let orderBy = words [ "ORDER"; "BY" ] .>> spaces >>. commaSeparated expr
+  let orderSpec =
+    expr .>>. opt (asc <|> desc) .>>. opt (nullsFirst <|> nullsLast) .>> spaces
+    |>> (fun ((expr, direction), nullsBehavior) -> Expression.OrderSpec(expr, direction, nullsBehavior))
+
+  let orderBy = words [ "ORDER"; "BY" ] .>> spaces >>. commaSeparated orderSpec
 
   let groupBy = words [ "GROUP"; "BY" ] .>> spaces >>. commaSeparated expr
 

--- a/src/OpenDiffix.Core/ParserTypes.fs
+++ b/src/OpenDiffix.Core/ParserTypes.fs
@@ -44,7 +44,7 @@ and Expression =
   | Join of joinType: JoinType * left: Expression * right: Expression * on: Expression
   | SubQuery of subQuery: SelectQuery * alias: string
   | Function of functionName: string * Expression list
-  | OrderSpec of expr: Expression * direction: Expression option * nullsBehavior: Expression option
+  | OrderSpec of expr: Expression * direction: Expression * nullsBehavior: Expression
   | SelectQuery of SelectQuery
 // Please notice the lack of the BETWEEN WHERE-clause construct. I couldn't get it to work!!! :/
 // If added as a Ternary parser with "BETWEEN" and "AND" being the phrases to look for, then

--- a/src/OpenDiffix.Core/ParserTypes.fs
+++ b/src/OpenDiffix.Core/ParserTypes.fs
@@ -20,6 +20,10 @@ type SelectQuery =
 and Expression =
   | Star
   | Null
+  | Asc
+  | Desc
+  | NullsFirst
+  | NullsLast
   | Integer of int64
   | Float of float
   | String of string
@@ -40,6 +44,7 @@ and Expression =
   | Join of joinType: JoinType * left: Expression * right: Expression * on: Expression
   | SubQuery of subQuery: SelectQuery * alias: string
   | Function of functionName: string * Expression list
+  | OrderSpec of expr: Expression * direction: Expression option * nullsBehavior: Expression option
   | SelectQuery of SelectQuery
 // Please notice the lack of the BETWEEN WHERE-clause construct. I couldn't get it to work!!! :/
 // If added as a Ternary parser with "BETWEEN" and "AND" being the phrases to look for, then

--- a/src/OpenDiffix.Core/ParserTypes.fs
+++ b/src/OpenDiffix.Core/ParserTypes.fs
@@ -14,6 +14,7 @@ type SelectQuery =
     GroupBy: Expression list
     Having: Expression option
     Limit: uint option
+    OrderBy: Expression list
   }
 
 and Expression =


### PR DESCRIPTION
Closes #272. Adds parser and analyzer support for ORDER BY clauses.

handling `ORDER BY` by aliases to be tackled separately, for now as workaround use the target expression index as in

```
SELECT age, city, count(DISTINCT ID) as c FROM customers GROUP BY age, city ORDER BY 3
```

instead of

```
SELECT age, city, count(DISTINCT ID) as c FROM customers GROUP BY age, city ORDER BY c
```

I'm still scratching my head, if there are any anonymity-related concerns with ORDER BY, or things will "just work".