### PR TITLE
Generate data to CSV

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,2 +1,3 @@
 data.sqlite
 data.config
+customers.csv


### PR DESCRIPTION
Expands the `generate.fsx` to produce CSV file representing the `customers` table from the SQLite file. Aims to be used for https://github.com/diffix/desktop/pull/246