### PR TITLE
Keep track of row count in buckets

### DIFF
--- a/src/OpenDiffix.Core/CommonTypes.fs
+++ b/src/OpenDiffix.Core/CommonTypes.fs
@@ -232,6 +232,7 @@ type AggregationContext =
 type Bucket =
   {
     Group: Row
+    mutable RowCount: int
     Aggregators: IAggregator array
     ExecutionContext: ExecutionContext
     Attributes: Dictionary<string, Value>
@@ -361,6 +362,7 @@ module Bucket =
   let make group aggregators executionContext =
     {
       Group = group
+      RowCount = 0
       Aggregators = aggregators
       ExecutionContext = executionContext
       Attributes = Dictionary<string, Value>()

--- a/src/OpenDiffix.Core/Executor.fs
+++ b/src/OpenDiffix.Core/Executor.fs
@@ -89,6 +89,8 @@ let private executeAggregate executionContext (childPlan, groupingLabels, aggreg
         state.[group] <- bucket
         bucket
 
+    bucket.RowCount <- bucket.RowCount + 1
+
     bucket.Aggregators
     |> Array.iteri (fun i aggregator -> aggArgs.[i] |> List.map argEvaluator |> aggregator.Transition)
 


### PR DESCRIPTION
This will also be useful to get a summary without the result iteration that desktop does.