### PR TITLE
Refactor Bucket.make to always include bucket_value in seed

### DIFF
--- a/src/OpenDiffix.Core/Bucket.fs
+++ b/src/OpenDiffix.Core/Bucket.fs
@@ -1,0 +1,26 @@
+module OpenDiffix.Core.Bucket
+
+let private addValuesToSeed seed (values: Value seq) =
+  values |> Seq.map Value.toString |> Hash.strings seed
+
+let make group aggregators executionContext =
+  let bucketExecutionContext =
+    { executionContext with
+        NoiseLayers =
+          { executionContext.NoiseLayers with
+              BucketSeed = addValuesToSeed executionContext.NoiseLayers.BucketSeed group
+          }
+    }
+
+  {
+    Group = group
+    RowCount = 0
+    Aggregators = aggregators
+    ExecutionContext = bucketExecutionContext
+    Attributes = Dictionary<string, Value>()
+  }
+
+let getAttribute attr bucket =
+  bucket.Attributes |> Dictionary.getOrDefault attr Null
+
+let putAttribute attr value bucket = bucket.Attributes.[attr] <- value

--- a/src/OpenDiffix.Core/CommonTypes.fs
+++ b/src/OpenDiffix.Core/CommonTypes.fs
@@ -358,21 +358,6 @@ module ExecutionContext =
   let makeDefault () =
     fromQueryContext (QueryContext.makeDefault ())
 
-module Bucket =
-  let make group aggregators executionContext =
-    {
-      Group = group
-      RowCount = 0
-      Aggregators = aggregators
-      ExecutionContext = executionContext
-      Attributes = Dictionary<string, Value>()
-    }
-
-  let getAttribute attr bucket =
-    bucket.Attributes |> Dictionary.getOrDefault attr Null
-
-  let putAttribute attr value bucket = bucket.Attributes.[attr] <- value
-
 module Plan =
   let rec columnsCount (plan: Plan) =
     match plan with

--- a/src/OpenDiffix.Core/Executor.fs
+++ b/src/OpenDiffix.Core/Executor.fs
@@ -15,9 +15,6 @@ module Utils =
   let unpackAggregators aggregators =
     aggregators |> Seq.map unpackAggregator |> Seq.toArray
 
-  let addValuesToSeed seed values =
-    values |> Seq.map Value.toString |> Hash.strings seed
-
 // ----------------------------------------------------------------
 // Node execution
 // ----------------------------------------------------------------
@@ -77,15 +74,7 @@ let private executeAggregate executionContext (childPlan, groupingLabels, aggreg
       match state.TryGetValue(group) with
       | true, aggregators -> aggregators
       | false, _ ->
-        let bucketExecutionContext =
-          { executionContext with
-              NoiseLayers =
-                { executionContext.NoiseLayers with
-                    BucketSeed = Utils.addValuesToSeed executionContext.NoiseLayers.BucketSeed group
-                }
-          }
-
-        let bucket = makeBucket group bucketExecutionContext
+        let bucket = makeBucket group executionContext
         state.[group] <- bucket
         bucket
 

--- a/src/OpenDiffix.Core/OpenDiffix.Core.fsproj
+++ b/src/OpenDiffix.Core/OpenDiffix.Core.fsproj
@@ -7,6 +7,7 @@
     <Compile Include="Utils.fs" />
     <Compile Include="CommonTypes.fs" />
     <Compile Include="Value.fs" />
+    <Compile Include="Bucket.fs" />
     <Compile Include="Expression.fs" />
     <Compile Include="Anonymizer.fs" />
     <Compile Include="Aggregator.fs" />


### PR DESCRIPTION
Necessary for https://github.com/diffix/desktop/issues/289.

Now `Bucket.make` will always use `group` parameter to derive the `bucket_value` part of the SQL seed