### PR TITLE
Move LED and star bucket hooks to reference

### DIFF
--- a/src/OpenDiffix.Core.Tests/HookTestHelpers.fs
+++ b/src/OpenDiffix.Core.Tests/HookTestHelpers.fs
@@ -1,0 +1,47 @@
+module OpenDiffix.Core.HookTestHelpers
+
+open System
+
+let private noiselessAnonParams: AnonymizationParams =
+  {
+    TableSettings = Map []
+    Salt = [||]
+    Suppression = { LowThreshold = 3; LowMeanGap = 0.; LayerSD = 0. }
+    OutlierCount = { Lower = 1; Upper = 1 }
+    TopCount = { Lower = 1; Upper = 1 }
+    LayerNoiseSD = 0.
+  }
+
+let private csvReader (csv: string) =
+  let rows =
+    csv.Split("\n", StringSplitOptions.TrimEntries ||| StringSplitOptions.RemoveEmptyEntries)
+    |> Array.map (fun row -> row.Split(",", StringSplitOptions.TrimEntries))
+
+  { new IDataProvider with
+      member _.OpenTable(_table, _columnIndices) =
+        rows
+        |> Seq.skip 1
+        |> Seq.mapi (fun i row -> Array.append [| Integer(int64 i) |] (Array.map Value.String row))
+
+      member _.GetSchema() =
+        let columns =
+          rows.[0]
+          |> Array.map (fun name -> { Name = name; Type = StringType })
+          |> Array.toList
+
+        [
+          {
+            Name = "table"
+            Columns = { Name = "RowIndex"; Type = IntegerType } :: columns
+          }
+        ]
+
+      member _.Dispose() = ()
+  }
+
+let private withHooks hooks context =
+  { context with PostAggregationHooks = hooks }
+
+let run hooks csv query =
+  let queryContext = QueryContext.make noiselessAnonParams (csvReader csv) |> withHooks hooks
+  QueryEngine.run queryContext query

--- a/src/OpenDiffix.Core.Tests/Led.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Led.Tests.fs
@@ -1,0 +1,193 @@
+module OpenDiffix.Core.LedTests
+
+open Xunit
+open FsUnit.Xunit
+open CommonTypes
+
+let assertRowsDifference rows1 rows2 (diff: List<Row * Row>) =
+  List.zip rows1 rows2
+  |> List.filter (fun (left, right) -> Row.equalityComparer.Equals(left, right) |> not)
+  |> should equal diff
+
+let assertHookDifference csv query (diff: List<Row * Row>) =
+  let rows (result: QueryEngine.QueryResult) = result.Rows
+  let withoutHookRows = HookTestHelpers.run [] csv query |> rows
+  let withHookRows = HookTestHelpers.run [ Led.hook ] csv query |> rows
+
+  assertRowsDifference withoutHookRows withHookRows diff
+
+let assertHookFails csv query (errorFragment: string) =
+  try
+    HookTestHelpers.run [ Led.hook ] csv query |> ignore
+    failwith "Expecting query to fail"
+  with
+  | ex ->
+    let str = ex.Message.ToLower()
+
+    if str.Contains(errorFragment.ToLower()) then
+      ()
+    else
+      failwith $"Expecting error to contain '%s{errorFragment}'. Got '%s{str}' instead."
+
+let csvWithVictim =
+  """
+  dept,gender,title
+  math,m,prof
+  math,m,prof
+  math,m,prof
+  math,m,prof
+  math,f,prof
+  math,f,prof
+  math,f,prof
+  math,f,prof
+  history,m,prof
+  history,m,prof
+  history,m,prof
+  history,m,prof
+  history,f,prof
+  history,f,prof
+  history,f,prof
+  history,f,prof
+  cs,m,prof
+  cs,m,prof
+  cs,m,prof
+  cs,m,prof
+  cs,f,prof
+  """
+
+let csvWithTwoVictims = csvWithVictim + "\n" + "cs,f,prof"
+let csvWithThreeCsWomen = csvWithTwoVictims + "\n" + "cs,f,prof"
+let csvWithDifferentTitles = csvWithVictim + "\n" + "cs,f,asst"
+
+let csvWithProperStarBucket =
+  csvWithVictim
+  + """
+    biol,f,asst
+    chem,m,asst
+    biol,f,prof
+    """
+
+let query =
+  """
+  SELECT dept, gender, title, diffix_count(*, RowIndex), diffix_low_count(RowIndex)
+  FROM table
+  GROUP BY 1, 2, 3
+  """
+
+[<Fact>]
+let ``Merges victim bucket`` () =
+  assertHookDifference
+    csvWithVictim
+    query
+    [
+      [| String "cs"; String "m"; String "prof"; Integer 4L; Boolean false |],
+      [| String "cs"; String "m"; String "prof"; Integer 5L; Boolean false |]
+    ]
+
+[<Fact>]
+let ``Merges 2 victims with same title`` () =
+  assertHookDifference
+    csvWithTwoVictims
+    query
+    [
+      [| String "cs"; String "m"; String "prof"; Integer 4L; Boolean false |],
+      [| String "cs"; String "m"; String "prof"; Integer 6L; Boolean false |]
+    ]
+
+[<Fact>]
+let ``Does not merge high count buckets`` () =
+  assertHookDifference csvWithThreeCsWomen query []
+
+[<Fact>]
+let ``Does not merge if the victim cannot be singled out`` () =
+  assertHookDifference csvWithDifferentTitles query []
+
+[<Fact>]
+let ``Merges taking precedence before star bucket hook`` () =
+  // We get a hold of the star bucket results reference via side effects.
+  let mutable suppressedAnonCount = Null
+  let pullHookResultsCallback results = suppressedAnonCount <- results
+  let starBucketHook = StarBucket.hook pullHookResultsCallback
+
+  let rows (result: QueryEngine.QueryResult) = result.Rows
+  let withoutHookRows = HookTestHelpers.run [] csvWithProperStarBucket query |> rows
+
+  let withHookRows =
+    HookTestHelpers.run [ Led.hook; starBucketHook ] csvWithProperStarBucket query
+    |> rows
+
+  assertRowsDifference
+    withoutHookRows
+    withHookRows
+    [
+      [| String "cs"; String "m"; String "prof"; Integer 4L; Boolean false |],
+      [| String "cs"; String "m"; String "prof"; Integer 5L; Boolean false |]
+    ]
+
+  // 3 is correct, this is the number of suppressed rows, _we exclude_ the merged row
+  // from the star bucket.
+  suppressedAnonCount |> should equal (Integer 3L)
+
+[<Fact>]
+let ``Works with count distinct`` () =
+  assertHookDifference
+    csvWithVictim
+    """
+    SELECT dept, gender, title, diffix_count(distinct RowIndex, RowIndex), diffix_low_count(RowIndex)
+    FROM table
+    GROUP BY 1, 2, 3
+    """
+    [
+      [| String "cs"; String "m"; String "prof"; Integer 4L; Boolean false |],
+      [| String "cs"; String "m"; String "prof"; Integer 5L; Boolean false |]
+    ]
+
+[<Fact>]
+let ``Works when low count filter is in HAVING`` () =
+  assertHookDifference
+    csvWithVictim
+    """
+    SELECT dept, gender, title, diffix_count(*, RowIndex)
+    FROM table
+    GROUP BY 1, 2, 3
+    HAVING NOT diffix_low_count(RowIndex)
+    """
+    [
+      [| String "cs"; String "m"; String "prof"; Integer 4L |],  //
+      [| String "cs"; String "m"; String "prof"; Integer 5L |]
+    ]
+
+[<Fact>]
+let ``Requires low count filter aggregator in scope`` () =
+  assertHookFails
+    csvWithVictim
+    """
+    SELECT dept, gender, title, diffix_count(*, RowIndex)
+    FROM table
+    GROUP BY 1, 2, 3
+    """
+    "cannot find required DiffixLowCount aggregator"
+
+[<Fact>]
+let ``Ignores real count`` () =
+  assertHookDifference
+    csvWithVictim
+    """
+    SELECT dept, gender, title, count(*), diffix_count(*, RowIndex), diffix_low_count(RowIndex)
+    FROM table
+    GROUP BY 1, 2, 3
+    """
+    [
+      [| String "cs"; String "m"; String "prof"; Integer 4L; Integer 4L; Boolean false |],
+      [| String "cs"; String "m"; String "prof"; Integer 4L; Integer 5L; Boolean false |]
+    ]
+
+[<Fact>]
+let ``Ignores global aggregation`` () =
+  assertHookDifference
+    csvWithVictim
+    """
+    SELECT diffix_count(*, RowIndex)
+    FROM table
+    """
+    []

--- a/src/OpenDiffix.Core.Tests/OpenDiffix.Core.Tests.fsproj
+++ b/src/OpenDiffix.Core.Tests/OpenDiffix.Core.Tests.fsproj
@@ -18,6 +18,9 @@
     <Compile Include="Executor.Tests.fs" />
     <Compile Include="Normalizer.Tests.fs" />
     <Compile Include="QueryEngine.Tests.fs" />
+    <Compile Include="HookTestHelpers.fs" />
+    <Compile Include="Led.Tests.fs" />
+    <Compile Include="StarBucket.Tests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/OpenDiffix.Core.Tests/StarBucket.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/StarBucket.Tests.fs
@@ -1,0 +1,50 @@
+module OpenDiffix.Core.StarBucketTests
+
+open Xunit
+open FsUnit.Xunit
+open CommonTypes
+
+// C and D are below the default lowThresh of 3 and will be suppressed
+let csv =
+  """
+  letter
+  A
+  A
+  A
+  B
+  B
+  B
+  C
+  C
+  D
+  """
+
+// now only C is below the default lowThresh, and so is the *-bucket
+let csvSuppressedStarBucket = csv.Replace("D\n", "")
+
+let query =
+  """
+  SELECT letter, diffix_count(*, RowIndex), diffix_low_count(RowIndex)
+  FROM table
+  GROUP BY 1
+  """
+
+[<Fact>]
+let ``Counts all suppressed buckets`` () =
+  let mutable suppressedAnonCount = Null
+  let pullHookResultsCallback results = suppressedAnonCount <- results
+
+  HookTestHelpers.run [ StarBucket.hook pullHookResultsCallback ] csv query
+  |> ignore
+
+  suppressedAnonCount |> should equal (Integer 3L)
+
+[<Fact>]
+let ``Counts all suppressed buckets, but suppresses the star bucket`` () =
+  let mutable suppressedAnonCount = Null
+  let pullHookResultsCallback results = suppressedAnonCount <- results
+
+  HookTestHelpers.run [ StarBucket.hook pullHookResultsCallback ] csvSuppressedStarBucket query
+  |> ignore
+
+  suppressedAnonCount |> should equal Null

--- a/src/OpenDiffix.Core/Bucket.fs
+++ b/src/OpenDiffix.Core/Bucket.fs
@@ -24,3 +24,7 @@ let getAttribute attr bucket =
   bucket.Attributes |> Dictionary.getOrDefault attr Null
 
 let putAttribute attr value bucket = bucket.Attributes.[attr] <- value
+
+let isLowCount lowCountIndex bucket =
+  bucket.Aggregators.[lowCountIndex].Final(bucket.ExecutionContext)
+  |> Value.unwrapBoolean

--- a/src/OpenDiffix.Core/Led.fs
+++ b/src/OpenDiffix.Core/Led.fs
@@ -1,0 +1,244 @@
+module OpenDiffix.Core.Led
+
+open System
+open CommonTypes
+
+let private startStopwatch () = Diagnostics.Stopwatch.StartNew()
+
+let private logDebug msg = Logger.debug $"[LED] {msg}"
+
+let inline private uncheckedAdd x y = Operators.op_Addition x y
+let inline private uncheckedMul x y = Operators.op_Multiply x y
+
+let private fastRowHash (row: Row) =
+  let mutable hash = 0
+
+  for value in row do
+    hash <- uncheckedAdd (uncheckedMul hash 9176) (value.GetHashCode())
+
+  Math.Abs(hash)
+
+/// Converts the sequence to an array, casting if it's already one.
+let private toArray (seq: 'a seq) : 'a array =
+  match seq with
+  | :? ('a array) as arr -> arr
+  | _ -> Seq.toArray seq
+
+// ----------------------------------------------------------------
+// Bucket merging
+// ----------------------------------------------------------------
+
+/// Returns an array of indexes pointing to anonymizing aggregators (diffix count, low count).
+let private anonymizingAggregatorIndexes (aggregationContext: AggregationContext) =
+  aggregationContext.Aggregators
+  |> Seq.map fst
+  |> Seq.indexed
+  |> Seq.choose (fun (i, aggSpec) -> if Aggregator.isAnonymizing aggSpec then Some i else None)
+  |> Seq.toArray
+
+/// Merges only given indexes from source bucket to destination bucket.
+let private mergeGivenAggregatorsInto (targetBucket: Bucket) aggIndexes (sourceBucket: Bucket) =
+  targetBucket.RowCount <- targetBucket.RowCount + 1
+
+  let sourceAggregators = sourceBucket.Aggregators
+  let targetAggregators = targetBucket.Aggregators
+
+  for i in aggIndexes do
+    targetAggregators.[i].Merge(sourceAggregators.[i])
+
+// ----------------------------------------------------------------
+// Main LED
+// ----------------------------------------------------------------
+
+type private Interlocked = Threading.Interlocked
+
+type private LedDiagnostics() =
+  // Bucket size vs. how many merges for that size occurred
+  let mergeHistogram = Dictionary<int, int>()
+
+  // How many buckets with isolating columns are found
+  let mutable bucketsIsolatingColumn = 0
+
+  // How many buckets with unknown columns are found
+  let mutable bucketsUnknownColumn = 0
+
+  // How many buckets are merged (at least once)
+  let mutable bucketsMerged = 0
+
+  member this.IncrementBucketsIsolatingColumn() =
+    Interlocked.Increment(&bucketsIsolatingColumn) |> ignore
+
+  member this.IncrementBucketsUnknownColumn() =
+    Interlocked.Increment(&bucketsUnknownColumn) |> ignore
+
+  member this.IncrementBucketsMerged() =
+    Interlocked.Increment(&bucketsMerged) |> ignore
+
+  member this.IncrementMerge(bucketCount: int) =
+    // Not thread safe!
+    mergeHistogram |> Dictionary.increment bucketCount
+
+  member this.Print(totalBuckets: int, suppressedBuckets: int) =
+    let mergeHistogramStr =
+      mergeHistogram
+      |> Seq.sortBy (fun pair -> pair.Key)
+      |> Seq.map (fun pair -> $"({pair.Key}, {pair.Value})")
+      |> Seq.append [ $"(*, {mergeHistogram |> Seq.sumBy (fun pair -> pair.Value)})" ]
+      |> String.join " "
+
+    logDebug $"Total buckets: {totalBuckets}"
+    logDebug $"Suppressed buckets: {suppressedBuckets}"
+    logDebug $"Buckets with isolating column(s): {bucketsIsolatingColumn}"
+    logDebug $"Buckets with unknown column(s): {bucketsUnknownColumn}"
+    logDebug $"Merged buckets: {bucketsMerged}"
+    logDebug $"Merge distribution: {mergeHistogramStr}"
+
+/// Reference wrapper for a System.Threading.SpinLock struct.
+type private SpinLock() =
+  let mutable lock = Threading.SpinLock()
+
+  member this.Enter() =
+    let mutable entered = false
+    lock.Enter(&entered)
+    if not entered then failwith "Failed to enter lock."
+
+  member this.Exit() = lock.Exit()
+
+type private SiblingsPerColumn = MutableList<Bucket * bool>
+
+let private initSiblings () = SiblingsPerColumn(3)
+
+/// Copies source array but skips the given index.
+let private sliceArray skipAt (source: Row) =
+  let targetLength = source.Length - 1
+  let target = Array.zeroCreate targetLength
+  Array.blit source 0 target 0 skipAt
+  Array.blit source (skipAt + 1) target skipAt (targetLength - skipAt)
+  target
+
+/// Returns victim buckets and their siblings per column.
+let private prepareBuckets (aggregationContext: AggregationContext) (buckets: Bucket array) =
+  let stopwatch = startStopwatch ()
+  let lowCountIndex = AggregationContext.lowCountIndex aggregationContext
+  let groupingLabelsLength = aggregationContext.GroupingLabels.Length
+
+  let CACHE_DISTRIBUTION = 53 // Prime number for better distribution, determined empirically.
+
+  // For each column, we build a cache where we group buckets by their labels EXCLUDING that column.
+  // This means that every cache will associate siblings where the respective column is different.
+  // Dictionaries are spread in CACHE_DISTRIBUTION parts to reduce lock contention.
+  let siblingCaches =
+    Array.init
+      groupingLabelsLength
+      (fun _col ->
+        Array.init
+          CACHE_DISTRIBUTION
+          (fun _cacheNo -> Dictionary<Row, SiblingsPerColumn>(Row.equalityComparer), SpinLock())
+      )
+
+  // Filters low count buckets and builds caches in the same pass.
+  let victimBuckets =
+    buckets
+    |> Array.Parallel.choose (fun bucket ->
+      let lowCount = Bucket.isLowCount lowCountIndex bucket
+      let bucketTuple = bucket, lowCount
+      let columnValues = bucket.Group
+      let siblingsPerColumn = Array.zeroCreate<SiblingsPerColumn> groupingLabelsLength
+
+      // Put entries in caches and store a reference to the (mutable) list of siblings.
+      for colIndex in 0 .. groupingLabelsLength - 1 do
+        let key = sliceArray colIndex columnValues
+        let keyHash = fastRowHash key
+        let cache, lock = siblingCaches.[colIndex].[keyHash % CACHE_DISTRIBUTION]
+
+        // Get exclusive access to this cache.
+        lock.Enter()
+        let siblings = cache |> Dictionary.getOrInit key initSiblings
+        siblingsPerColumn.[colIndex] <- siblings
+        // We don't actually need more than 3 values.
+        // 1 = no siblings; 2 = single sibling; 3 = multiple siblings
+        if siblings.Count < 3 then siblings.Add(bucketTuple)
+        lock.Exit()
+
+      if lowCount then Some(bucket, siblingsPerColumn) else None
+    )
+
+  logDebug $"Cache building took {stopwatch.Elapsed}"
+
+  victimBuckets
+
+/// Main LED logic.
+let private led (aggregationContext: AggregationContext) (buckets: Bucket array) =
+  let diagnostics = LedDiagnostics()
+  let victimBuckets = prepareBuckets aggregationContext buckets
+
+  let stopwatch = startStopwatch ()
+
+  let anonAggregators = anonymizingAggregatorIndexes aggregationContext
+  let groupingLabelsLength = aggregationContext.GroupingLabels.Length
+
+  /// Returns `Some(victimBucket, mergeTargets)` if victimBucket has an unknown column
+  /// and has merge targets (siblings which match isolating column criteria).
+  let chooseMergeTargets (victimBucket: Bucket, siblingsPerColumn: SiblingsPerColumn array) =
+    let mutable hasUnknownColumn = false
+    let mergeTargets = MutableList()
+
+    for colIndex in 0 .. groupingLabelsLength - 1 do
+      let siblings = siblingsPerColumn.[colIndex]
+
+      match siblings.Count with
+      | 1 ->
+        // No siblings for this column (Count=1 means itself).
+        // A column without siblings is an unknown column.
+        hasUnknownColumn <- true
+      | 2 ->
+        // Single sibling (self+other). Find it and check if it's high count.
+        // A column with a single high-count sibling is an isolating column.
+        for siblingBucket, siblingLowCount in siblings do
+          if not (obj.ReferenceEquals(victimBucket, siblingBucket)) && not siblingLowCount then
+            mergeTargets.Add(siblingBucket)
+      | _ ->
+        // Count=3 means there are multiple siblings and has no special meaning.
+        ()
+
+    if hasUnknownColumn then diagnostics.IncrementBucketsUnknownColumn()
+    if mergeTargets.Count > 0 then diagnostics.IncrementBucketsIsolatingColumn()
+
+    if hasUnknownColumn && mergeTargets.Count > 0 then
+      Some(victimBucket, mergeTargets)
+    else
+      None
+
+  victimBuckets
+  |> Array.Parallel.choose chooseMergeTargets
+  |> Array.iter (fun (victimBucket, mergeTargets) ->
+    diagnostics.IncrementBucketsMerged()
+    Bucket.putAttribute BucketAttributes.IS_LED_MERGED (Boolean true) victimBucket
+
+    for siblingBucket in mergeTargets do
+      victimBucket |> mergeGivenAggregatorsInto siblingBucket anonAggregators
+      diagnostics.IncrementMerge(victimBucket.RowCount)
+  )
+
+  diagnostics.Print(buckets.Length, victimBuckets.Length)
+  logDebug $"Led merging took {stopwatch.Elapsed}"
+
+// ----------------------------------------------------------------
+// Public API
+// ----------------------------------------------------------------
+
+let hook (aggregationContext: AggregationContext) (buckets: Bucket seq) =
+  let stopwatch = startStopwatch ()
+
+  try
+    // LED requires at least 2 columns - an isolating column and an unknown column.
+    // With exactly 2 columns attacks are not useful because
+    // they would have to isolate victims against the whole dataset.
+    if aggregationContext.GroupingLabels.Length <= 2 then
+      buckets
+    else
+      let buckets = toArray buckets
+      led aggregationContext buckets
+      buckets :> Bucket seq
+  finally
+    logDebug $"Hook took {stopwatch.Elapsed}"

--- a/src/OpenDiffix.Core/OpenDiffix.Core.fsproj
+++ b/src/OpenDiffix.Core/OpenDiffix.Core.fsproj
@@ -21,6 +21,8 @@
     <Compile Include="Planner.fs" />
     <Compile Include="Executor.fs" />
     <Compile Include="QueryEngine.fs" />
+    <Compile Include="Led.fs" />
+    <Compile Include="StarBucket.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.78" />

--- a/src/OpenDiffix.Core/StarBucket.fs
+++ b/src/OpenDiffix.Core/StarBucket.fs
@@ -1,0 +1,63 @@
+module OpenDiffix.Core.StarBucket
+
+/// Merges all source aggregators into the target bucket.
+let private mergeAllAggregatorsInto (targetBucket: Bucket) (sourceBucket: Bucket) =
+  let targetAggregators = targetBucket.Aggregators
+
+  sourceBucket.Aggregators |> Array.iteri (fun i -> targetAggregators.[i].Merge)
+
+let private makeStarBucket (aggregationContext: AggregationContext) =
+  let isGlobal = aggregationContext.GroupingLabels.Length = 0
+
+  let executionContext = aggregationContext.ExecutionContext
+
+  // Group labels are all '*'s
+  let group = Array.create aggregationContext.GroupingLabels.Length (String "*")
+
+  let aggregators =
+    aggregationContext.Aggregators
+    |> Seq.map fst
+    |> Seq.map (Aggregator.create executionContext isGlobal)
+    |> Seq.toArray
+
+  let starBucket = Bucket.make group aggregators executionContext
+  // Not currently used, but may be in the future.
+  starBucket |> Bucket.putAttribute BucketAttributes.IS_STAR_BUCKET (Boolean true)
+  starBucket
+
+let hook callback (aggregationContext: AggregationContext) (buckets: Bucket seq) =
+  let starBucket = makeStarBucket aggregationContext
+  let lowCountIndex = AggregationContext.lowCountIndex aggregationContext
+  let diffixCountIndex = AggregationContext.diffixCountIndex aggregationContext
+
+  let isInStarBucket bucket =
+    let isAlreadyMerged =
+      bucket
+      |> Bucket.getAttribute BucketAttributes.IS_LED_MERGED
+      |> Value.unwrapBoolean
+
+    not isAlreadyMerged && Bucket.isLowCount lowCountIndex bucket
+
+  let bucketsInStarBucket =
+    buckets
+    |> Seq.filter isInStarBucket
+    |> Seq.map (mergeAllAggregatorsInto starBucket)
+    |> Seq.length
+
+  let executionContext = starBucket.ExecutionContext
+
+  let isStarBucketLowCount =
+    starBucket.Aggregators.[lowCountIndex].Final(executionContext)
+    |> Value.unwrapBoolean
+
+  let suppressedAnonCount =
+    // NOTE: we can have a star bucket consisting of a single suppressed bucket,
+    // which won't be suppressed by itself (different noise seed). In such case,
+    // we must enforce the suppression manually.
+    if isStarBucketLowCount || bucketsInStarBucket < 2 then
+      Null
+    else
+      starBucket.Aggregators.[diffixCountIndex].Final(executionContext)
+
+  callback suppressedAnonCount
+  buckets


### PR DESCRIPTION
Mostly copy and paste, except for the CSV emulator and some other glue moved to relevant modules.