### PR TITLE
Update ORDER BY to match that of PostgreSQL

### DIFF
--- a/src/OpenDiffix.Core.Tests/Value.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Value.Tests.fs
@@ -44,3 +44,21 @@ module ComparerTests =
     [ Integer 10L; Null; Integer 1L; Null; Integer 5L ]
     |> sort Descending NullsLast
     |> should equal [ Integer 10L; Integer 5L; Integer 1L; Null; Null ]
+
+  [<Fact>]
+  let ``String sort groups by letter case`` () =
+    [ String "a"; String "C"; String "A"; String "c" ]
+    |> sort Ascending NullsLast
+    |> should equal [ String "a"; String "A"; String "c"; String "C" ]
+
+  [<Fact>]
+  let ``String sort ignores whitespace and symbols`` () =
+    [ String " a"; String "  C"; String "+  A"; String "   c" ]
+    |> sort Ascending NullsLast
+    |> should equal [ String " a"; String "+  A"; String "   c"; String "  C" ]
+
+  [<Fact>]
+  let ``String sort uses whitespace and symbols comparison on conflict`` () =
+    [ String "+a"; String "a"; String " a"; String "b" ]
+    |> sort Ascending NullsLast
+    |> should equal [ String " a"; String "+a"; String "a"; String "b" ]

--- a/src/OpenDiffix.Core/Value.fs
+++ b/src/OpenDiffix.Core/Value.fs
@@ -3,6 +3,11 @@ module OpenDiffix.Core.Value
 open System
 open System.Globalization
 
+/// Sort-related constants
+let private stringCompareInfo = CompareInfo.GetCompareInfo("en-US")
+let private ignoreSymbolsFlag = CompareOptions.IgnoreSymbols + CompareOptions.StringSort
+let private stringSortFlag = CompareOptions.StringSort
+
 /// Converts a value to its string representation.
 let rec toString value =
   match value with
@@ -48,19 +53,18 @@ let comparer direction nulls =
     | Null, _ -> nullsValue
     | _, Null -> -nullsValue
     | String x, String y ->
-      // Using PostgreSQL string comparison as a template
-      let compareInfo = CompareInfo.GetCompareInfo("en-US")
-      // we want whitespace & punctuation comparison ("symbols" in .NET) to have smaller priority,
-      // so we ignore first.
-      let comparisonIgnoreSymbols =
-        directionValue
-        * compareInfo.Compare(x, y, CompareOptions.IgnoreSymbols + CompareOptions.StringSort)
-      // if the former gives a tie, we include symbols.  `StringSort` means they come last and we group letter cases together
-      // reference: https://wiki.postgresql.org/wiki/FAQ#Why_do_my_strings_sort_incorrectly.3F
+      // Using PostgreSQL string comparison as a template.
+      // https://wiki.postgresql.org/wiki/FAQ#Why_do_my_strings_sort_incorrectly.3F
+
+      // We want whitespace & punctuation comparison ("symbols" in .NET) to have smaller priority,
+      // so we ignore them first.
+      let comparisonIgnoreSymbols = directionValue * stringCompareInfo.Compare(x, y, ignoreSymbolsFlag)
+      // If the former gives a tie, we include symbols.
       if (comparisonIgnoreSymbols <> 0) then
         comparisonIgnoreSymbols
       else
-        directionValue * compareInfo.Compare(x, y, CompareOptions.StringSort)
+        // `StringSort` means symbols come last and we group letter cases together.
+        directionValue * stringCompareInfo.Compare(x, y, stringSortFlag)
     | x, y -> directionValue * Operators.compare x y
 
 /// Computes a 64 bit hash of the given value.

--- a/src/OpenDiffix.Core/Value.fs
+++ b/src/OpenDiffix.Core/Value.fs
@@ -46,6 +46,7 @@ let comparer direction nulls =
     | Null, Null -> 0
     | Null, _ -> nullsValue
     | _, Null -> -nullsValue
+    | String x, String y -> directionValue * (StringComparer.OrdinalIgnoreCase.Compare(x, y))
     | x, y -> directionValue * Operators.compare x y
 
 /// Computes a 64 bit hash of the given value.


### PR DESCRIPTION
Split out of the property based testing spike. This is the only change to the `reference` implementation required to make these tests pass.