### PR TITLE
Make the outlier/topRange flattening algorithm tolerate compacting

### DIFF
--- a/src/OpenDiffix.Core/Anonymizer.fs
+++ b/src/OpenDiffix.Core/Anonymizer.fs
@@ -85,7 +85,7 @@ let compactFlatteningIntervals outlierCount topCount totalCount =
         | false, false ->
           // Not possible. Otherwise `outlierRange + topRange < outlierAdjustment + topAdjustment = totalAdjustment` but we
           // knew the opposite was true in (*) above
-          failwith "Not possible"
+          failwith "Internal error - impossible interval compacting"
 
     Some compactIntervals
 

--- a/src/OpenDiffix.Core/Anonymizer.fs
+++ b/src/OpenDiffix.Core/Anonymizer.fs
@@ -47,25 +47,39 @@ let private generateNoise salt stepName stdDev noiseLayers =
 
 // Compacts flattening intervals to fit into the total count of contributors.
 // Both intervals are reduced proportionally, with `topCount` taking priority.
+// NOTE `totalCount >= outlierCount.Lower + topCount.Lower` is assumed
 let private compactFlatteningIntervals outlierCount topCount totalCount =
   let totalAdjustment = outlierCount.Upper + topCount.Upper - totalCount
 
   if totalAdjustment <= 0 then
     outlierCount, topCount // no adjustment needed
   else
+    // NOTE: at this point we know `0 <= totalAdjustment <= outlierRange + topRange` (*)
+    //       because `totalAdjustment = outlierCount.Upper + topCount.Upper - totalCount
+    //                               <= outlierCount.Upper + topCount.Upper - outlierCount.Lower - topCount.Lower`
+    //       by the condition checked in `aidFlattening`
     let outlierRange = outlierCount.Upper - outlierCount.Lower
+    let topRange = topCount.Upper - topCount.Lower
+    // `topAdjustment` will be half of `totalAdjustment` rounded up, so it takes priority as it should
+    let outlierAdjustment = totalAdjustment / 2
+    let topAdjustment = totalAdjustment - outlierAdjustment
 
-    if outlierRange > topCount.Upper - topCount.Lower then
-      failwith "Invalid config: OutlierCount interval is larger than TopCount interval."
-
-    let outlierAdjustment, topAdjustment =
-      if outlierRange < totalAdjustment / 2 then
-        outlierRange, totalAdjustment - outlierRange
-      else
-        totalAdjustment / 2, totalAdjustment - totalAdjustment / 2
-
-    { outlierCount with Upper = outlierCount.Upper - outlierAdjustment },
-    { topCount with Upper = topCount.Upper - topAdjustment }
+    if outlierRange >= outlierAdjustment && topRange >= topAdjustment then
+      // both ranges are compacted at same rate
+      { outlierCount with Upper = outlierCount.Upper - outlierAdjustment },
+      { topCount with Upper = topCount.Upper - topAdjustment }
+    elif outlierRange < outlierAdjustment then
+      // `outlierCount` is compacted as much as possible by `outlierRange`, `topCount` takes the surplus adjustment
+      { outlierCount with Upper = outlierCount.Lower },
+      { topCount with Upper = topCount.Upper - totalAdjustment + outlierRange }
+    elif topRange < topAdjustment then
+      // vice versa
+      { outlierCount with Upper = outlierCount.Upper - totalAdjustment + topRange },
+      { topCount with Upper = topCount.Lower }
+    else
+      // Not possible. Otherwise `outlierRange + topRange < outlierAdjustment + topAdjustment = totalAdjustment` but we
+      // knew the opposite was true in (*) above
+      failwith "Not possible"
 
 type private AidCount = { FlattenedSum: float; Flattening: float; NoiseSD: float; Noise: float }
 
@@ -75,12 +89,12 @@ let inline private aidFlattening
   (aidContributions: (AidHash * ^Contribution) array)
   : AidCount option =
   let anonParams = executionContext.AnonymizationParams
+  let totalCount = aidContributions.Length
 
-  if aidContributions.Length < anonParams.OutlierCount.Lower + anonParams.TopCount.Lower then
+  if totalCount < anonParams.OutlierCount.Lower + anonParams.TopCount.Lower then
     None
   else
-    let outlierInterval, topInterval =
-      compactFlatteningIntervals anonParams.OutlierCount anonParams.TopCount aidContributions.Length
+    let outlierInterval, topInterval = compactFlatteningIntervals anonParams.OutlierCount anonParams.TopCount totalCount
 
     let sortedAidContributions = aidContributions |> Array.sortByDescending snd
 
@@ -109,7 +123,7 @@ let inline private aidFlattening
     let flattening = float outliersSummed - outlierReplacement
     let flattenedUnaccountedFor = float unaccountedFor - flattening |> max 0.
     let flattenedSum = float summedContributions - flattening
-    let flattenedAvg = flattenedSum / float aidContributions.Length
+    let flattenedAvg = flattenedSum / float totalCount
 
     let noiseScale = max flattenedAvg (0.5 * topGroupAverage)
     let noiseSD = anonParams.LayerNoiseSD * noiseScale


### PR DESCRIPTION
This comes out of our discussion on slack about the compacting algorithm.

Since we established, that compacting only on the `topRange` end isn't a problem, let's allow it. The benefit of this is that moving on, we don't restrict the `outlierRange` to be ~smaller~ narrower than `topRange`.

I also rearrange the code a little bit in order to be able to include some explanations in the comments, I hope this works for you. We could take this further by including the check in `aidFlattening` function in the `compact...` function, but I couldn't make up my mind which option is nicer.