### PR TITLE
Reject invalid `topCount` and `outlierCount` intervals

### DIFF
--- a/src/OpenDiffix.CLI.Tests/Program.Tests.fs
+++ b/src/OpenDiffix.CLI.Tests/Program.Tests.fs
@@ -39,6 +39,14 @@ let ``Rejects invalid SQL`` () =
   )
 
 [<Fact>]
+let ``Rejects invalid intervals`` () =
+  shouldFail (fun () ->
+    [| "-f"; dataDirectory; "--outlier-count"; "2"; "1"; "-q"; "SELECT count(*) FROM customers" |]
+    |> mainCore
+    |> ignore
+  )
+
+[<Fact>]
 let ``Guards against unknown params`` () =
   shouldFail (fun () ->
     [| "-f"; dataDirectory; "--foo"; "customers.id"; "-q"; "SELECT count(*) FROM customers" |]

--- a/src/OpenDiffix.CLI/Program.fs
+++ b/src/OpenDiffix.CLI/Program.fs
@@ -66,7 +66,8 @@ let failWithUsageInfo errorMsg =
 
 let toInterval =
   function
-  | Some (lower, upper) -> { Lower = lower; Upper = upper }
+  | Some (lower, upper) when lower <= upper -> { Lower = lower; Upper = upper }
+  | Some (lower, upper) -> failwith $"Invalid request: interval lower bound exceeds upper bound: (%i{lower}, %i{upper})"
   | _ -> Interval.Default
 
 let toNoise =


### PR DESCRIPTION
A tiny detail I've picked up along the way. Without this check, an attempt to do an invalid interval either slipped through or returned `ERROR: Attempted to divide by zero.` 