### PR TITLE
Support pretty printing of plans

### DIFF
--- a/src/OpenDiffix.Core/CommonTypes.fs
+++ b/src/OpenDiffix.Core/CommonTypes.fs
@@ -454,7 +454,7 @@ module Plan =
         + $"{propLine depth}Group Keys: {String.joinWithComma groupingLabels}"
         + $"{propLine depth}Aggregates: {String.joinWithComma aggregators}"
         + childToString childPlan
-      | Plan.Unique childPlan -> "Unique" + NEWLINE + (toString (depth + 1) childPlan)
+      | Plan.Unique childPlan -> "Unique" + childToString childPlan
       | Plan.Join (leftPlan, rightPlan, joinType, condition) ->
         $"{joinType} on {condition}" + childToString leftPlan + childToString rightPlan
       | Plan.Append (leftPlan, rightPlan) -> "Append" + childToString leftPlan + childToString rightPlan

--- a/src/OpenDiffix.Core/Utils.fs
+++ b/src/OpenDiffix.Core/Utils.fs
@@ -13,6 +13,8 @@ type Stack<'T> = Collections.Generic.Stack<'T>
 module String =
   let join (sep: string) (values: seq<'T>) = String.Join<'T>(sep, values)
 
+  let joinWithComma (values: seq<'T>) = join ", " values
+
   let equalsI s1 s2 =
     String.Equals(s1, s2, StringComparison.InvariantCultureIgnoreCase)
 


### PR DESCRIPTION
Can be dumped via `System.Diagnostics.Debug.WriteLine` while testing. Needs parser support if we want `EXPLAIN`.

Looks something like this:

```
Project $0
 -> Aggregate
     Group Keys: 
     Aggregates: DiffixCount([$1, $7])
     -> InnerJoin on Equals($7, $1)
         -> Seq Scan on purchases
         -> Seq Scan on customers_small
```

if we do #318 we can make the Vars friendlier.