### PR TITLE
Block anonymizing queries with subqueries/WHERE/JOIN

### DIFF
--- a/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
@@ -349,7 +349,7 @@ type Tests(db: DBFixture) =
   [<Fact>]
   let ``Detect queries joining tables with AID columns`` () =
     ensureQueryFails
-      "SELECT 1 FROM products JOIN customers_small ON true"
+      "SELECT price FROM products JOIN customers_small ON true"
       "JOIN in anonymizing queries is not currently supported"
 
   [<Fact>]

--- a/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
@@ -337,30 +337,19 @@ type Tests(db: DBFixture) =
 
     result.Having |> should equal expected
 
+  // NOTE: We do QueryValidator testing in its respective test module. Here we just check, if it's invoked at all based
+  // on whether the query is anonymizing.
   [<Fact>]
-  let ``Disallow anonymizing queries with JOINs`` () =
-    ensureQueryFails
-      "SELECT count(*) FROM customers_small JOIN purchases ON id = purchases.cid"
-      "JOIN in anonymizing queries is not currently supported"
-
-  [<Fact>]
-  let ``Disallow anonymizing queries with subqueries`` () =
+  let ``Detect subqueries touching tables with AID columns`` () =
     ensureQueryFails
       "SELECT count(*) FROM (SELECT 1 FROM customers_small) x"
       "Subqueries in anonymizing queries are not currently supported"
 
   [<Fact>]
-  let ``Allow non-anonymizing queries with JOINs`` () =
-    analyzeQuery "SELECT count(*) FROM products as a JOIN products as b ON a.id = b.id"
-    |> ignore
-
-  [<Fact>]
-  let ``Allow non-anonymizing queries with subqueries`` () =
-    analyzeQuery "SELECT count(*) FROM (SELECT 1 FROM products) x" |> ignore
-
-  [<Fact>]
-  let ``Allow limiting top query`` () =
-    analyzeQuery "SELECT count(*) FROM customers_small LIMIT 1" |> ignore
+  let ``Detect queries joining tables with AID columns`` () =
+    ensureQueryFails
+      "SELECT 1 FROM products JOIN customers_small ON true"
+      "JOIN in anonymizing queries is not currently supported"
 
   [<Fact>]
   let ``SQL seed from column selection`` () =

--- a/src/OpenDiffix.Core.Tests/QueryEngine.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/QueryEngine.Tests.fs
@@ -96,43 +96,7 @@ type Tests(db: DBFixture) =
            | Integer i -> Integer i
            | other -> failwith $"Unexpected return '%A{other}'"
 
-  [<Fact>]
-  let ``query 6 - cross join`` () =
-    "SELECT count(*) FROM customers_small, purchases WHERE id = cid"
-    |> runQueryToInteger
-    |> should equal (Integer 72L)
-
-  [<Fact>]
-  let ``query 7 - inner join`` () =
-    "SELECT count(*) FROM purchases join customers_small ON id = cid"
-    |> runQueryToInteger
-    |> should equal (Integer 72L)
-
-  [<Fact>]
-  let ``query 8 - left join`` () =
-    "SELECT count(*) FROM customers_small LEFT JOIN purchases ON id = cid"
-    |> runQueryToInteger
-    |> should equal (Integer 72L)
-
-  [<Fact>]
-  let ``query 9 - right join`` () =
-    // The underlying data looks like this:
-    //
-    // customer.ID = null, purchases.CID = null, COUNT
-    // false,              false,                73
-    // true,               false,                445
-    // true,               true,                 1
-    //
-    // The query should yield the 73 + 445 values,
-    // There are no flattening needed for purchases,
-    // and a flattening of 1 for the customers table.
-    // When anonymizing the customers table we have 445
-    // unaccounted for values
-    // This should give us: 73 - 1 + 445 - 1 = 516
-    "SELECT count(*) FROM customers_small RIGHT JOIN purchases ON id = cid"
-    |> runQueryToInteger
-    |> should equal (Integer 516L)
-
+  // query 6 - query 9 removed (anonymizing JOINs, which are not supported now)
   [<Fact>]
   let ``query 10`` () =
     let expected =
@@ -206,8 +170,8 @@ type Tests(db: DBFixture) =
       "SELECT count(*) AS c1, count(DISTINCT length(name)) AS c2 FROM (SELECT name FROM products) x"
 
     equivalentQueries
-      "SELECT count(*) FROM customers_small LEFT JOIN purchases ON id = cid"
-      "SELECT count(*) FROM (SELECT id, cid FROM customers_small LEFT JOIN purchases ON id = cid) x"
+      "SELECT count(*) FROM products as a LEFT JOIN products as b ON a.id = b.id"
+      "SELECT count(*) FROM (SELECT a.id, b.id FROM products as a LEFT JOIN products as b ON a.id = b.id) x"
 
   [<Fact>]
   let ``standard query can use diffix functions`` () =

--- a/src/OpenDiffix.Core.Tests/QueryValidator.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/QueryValidator.Tests.fs
@@ -60,16 +60,6 @@ let ``Only allow count(*) and count(distinct column)`` () =
   ensureAnalyzeValid "SELECT count(distinct int_col) FROM table"
 
 [<Fact>]
-let ``Disallow aggregates in subqueries`` () =
-  let errorFragment = "aggregates in subqueries"
-  ensureAnalyzeFails "SELECT c FROM (SELECT count(*) as c FROM table) x" errorFragment
-
-[<Fact>]
-let ``Disallow group by in subqueries`` () =
-  let errorFragment = "grouping in subqueries"
-  ensureAnalyzeFails "SELECT count(*) FROM (SELECT int_col FROM table GROUP BY 1) x" errorFragment
-
-[<Fact>]
 let ``Disallow multiple low count aggregators`` () =
   let errorFragment = "single low count aggregator is allowed"
 

--- a/src/OpenDiffix.Core.Tests/QueryValidator.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/QueryValidator.Tests.fs
@@ -87,6 +87,12 @@ let ``Allow limiting top query`` () =
   ensureAnalyzeValid "SELECT count(*) FROM table LIMIT 1"
 
 [<Fact>]
+let ``Disallow anonymizing queries with WHERE`` () =
+  ensureAnalyzeFails
+    "SELECT count(*) FROM table WHERE str_col=''"
+    "WHERE in anonymizing queries is not currently supported"
+
+[<Fact>]
 let ``Don't validate not anonymizing queries for unsupported anonymization features`` () =
   // Subqueries, JOINs, WHEREs, other aggregators etc.
   ensureAnalyzeNotAnonValid

--- a/src/OpenDiffix.Core/Planner.fs
+++ b/src/OpenDiffix.Core/Planner.fs
@@ -46,7 +46,7 @@ let rec private collectSetFunctions expression =
 
 let private planJoin join columnIndices =
   let leftColumnCount = QueryRange.columnsCount join.Left
-  let leftIndices, rightIndices = List.partition ((>) leftColumnCount) columnIndices
+  let leftIndices, rightIndices = List.partition (fun x -> x < leftColumnCount) columnIndices
   let rightIndices = List.map (fun i -> i - leftColumnCount) rightIndices
   Plan.Join(planFrom join.Left leftIndices, planFrom join.Right rightIndices, join.Type, join.On)
 

--- a/src/OpenDiffix.Core/Planner.fs
+++ b/src/OpenDiffix.Core/Planner.fs
@@ -46,7 +46,7 @@ let rec private collectSetFunctions expression =
 
 let private planJoin join columnIndices =
   let leftColumnCount = QueryRange.columnsCount join.Left
-  let leftIndices, rightIndices = List.partition ((>=) leftColumnCount) columnIndices
+  let leftIndices, rightIndices = List.partition ((>) leftColumnCount) columnIndices
   let rightIndices = List.map (fun i -> i - leftColumnCount) rightIndices
   Plan.Join(planFrom join.Left leftIndices, planFrom join.Right rightIndices, join.Type, join.On)
 

--- a/src/OpenDiffix.Core/QueryValidator.fs
+++ b/src/OpenDiffix.Core/QueryValidator.fs
@@ -44,6 +44,10 @@ let private validateSelectTarget (selectQuery: SelectQuery) =
   | SubQuery _ -> failwith "Subqueries in anonymizing queries are not currently supported"
   | _ -> ()
 
+let private validateNoWhere (selectQuery: SelectQuery) =
+  if selectQuery.Where <> Constant(Boolean true) then
+    failwith "WHERE in anonymizing queries is not currently supported"
+
 // ----------------------------------------------------------------
 // Public API
 // ----------------------------------------------------------------
@@ -55,4 +59,5 @@ let validateQuery isAnonymizing (selectQuery: SelectQuery) =
   if isAnonymizing then
     validateOnlyCount selectQuery
     allowedCountUsage selectQuery
+    validateNoWhere selectQuery
     validateSelectTarget selectQuery

--- a/src/OpenDiffix.Core/QueryValidator.fs
+++ b/src/OpenDiffix.Core/QueryValidator.fs
@@ -38,21 +38,11 @@ let private allowedCountUsage query =
     | _ -> ()
   )
 
-let private validateSubQuery selectQuery =
-  selectQuery
-  |> visitAggregates (fun _ -> failwith "Aggregates in subqueries are not currently supported")
-
-  if not (List.isEmpty selectQuery.GroupBy) then
-    failwith "Grouping in subqueries is not currently supported"
-
-  validateSelectTarget selectQuery
-  validateLimitUsage selectQuery
-
-let private validateSelectTarget selectQuery = selectQuery |> visit validateSubQuery
-
-let private validateLimitUsage selectQuery =
-  if selectQuery.Limit <> None then
-    failwith "Limit is not allowed in anonymizing subqueries"
+let private validateSelectTarget (selectQuery: SelectQuery) =
+  match selectQuery.From with
+  | Join _ -> failwith "JOIN in anonymizing queries is not currently supported"
+  | SubQuery _ -> failwith "Subqueries in anonymizing queries are not currently supported"
+  | _ -> ()
 
 // ----------------------------------------------------------------
 // Public API


### PR DESCRIPTION
Closes #323.

As title + I spotted a bug related to joins. If the second (right) joined table had it's _first_ column in the target list, it would end up being treated as the first (left) table, resulting in an out of bounds error, e.g.:

```dotnet run --project reference/src/OpenDiffix.CLI/ -- -f reference/data/data.sqlite -q "SELECT b.age FROM customers as a JOIN customers as b ON a.id=b.id"```

```ERROR: The index was outside the range of elements in the list. (Parameter 'n')```