### PR TITLE
Additional test: ceil and round blocked in untrusted mode + rename

### DIFF
--- a/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
@@ -405,6 +405,14 @@ type Tests(db: DBFixture) =
       "Generalization used in the query is not allowed in untrusted access level"
 
     ensureQueryFailsUntrusted
+      "SELECT round(age) from customers"
+      "Generalization used in the query is not allowed in untrusted access level"
+
+    ensureQueryFailsUntrusted
+      "SELECT ceil(age) from customers"
+      "Generalization used in the query is not allowed in untrusted access level"
+
+    ensureQueryFailsUntrusted
       "SELECT width_bucket(age, 2, 200, 5) from customers"
       "Generalization used in the query is not allowed in untrusted access level"
 

--- a/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
@@ -397,22 +397,6 @@ type Tests(db: DBFixture) =
       "Generalization used in the query is not allowed in untrusted access level"
 
     ensureQueryFailsUntrusted
-      "SELECT round_by(age, 2) from customers"
-      "Generalization used in the query is not allowed in untrusted access level"
-
-    ensureQueryFailsUntrusted
-      "SELECT ceil_by(age, 2) from customers"
-      "Generalization used in the query is not allowed in untrusted access level"
-
-    ensureQueryFailsUntrusted
-      "SELECT round(age) from customers"
-      "Generalization used in the query is not allowed in untrusted access level"
-
-    ensureQueryFailsUntrusted
-      "SELECT ceil(age) from customers"
-      "Generalization used in the query is not allowed in untrusted access level"
-
-    ensureQueryFailsUntrusted
       "SELECT width_bucket(age, 2, 200, 5) from customers"
       "Generalization used in the query is not allowed in untrusted access level"
 
@@ -425,6 +409,11 @@ type Tests(db: DBFixture) =
     analyzeQueryUntrusted "SELECT floor_by(age, 0.2) from customers" |> ignore
     analyzeQueryUntrusted "SELECT floor_by(age, 20.0) from customers" |> ignore
     analyzeQueryUntrusted "SELECT floor_by(age, 50.0) from customers" |> ignore
+    analyzeQueryUntrusted "SELECT ceil_by(age, 50.0) from customers" |> ignore
+    analyzeQueryUntrusted "SELECT round_by(age, 50.0) from customers" |> ignore
+    // No generalization, either implicitly or explicitly
+    analyzeQueryUntrusted "SELECT floor(age) from customers" |> ignore
+    analyzeQueryUntrusted "SELECT age from customers" |> ignore
 
   [<Fact>]
   let ``Default SQL seed from non-anonymizing queries`` () =

--- a/src/OpenDiffix.Core/Analyzer.fs
+++ b/src/OpenDiffix.Core/Analyzer.fs
@@ -423,7 +423,7 @@ let rec private normalizeBucketLabelExpression expression =
     FunctionExpr(ScalarFunction fn, List.map normalizeBucketLabelExpression args @ extraArgs)
   | _ -> expression
 
-let private untrustedAllowsRange arg =
+let private isMoneyStyle arg =
   match arg with
   // "money-style" numbers, i.e. 1, 2, or 5 preceeded by or followed by zeros: ⟨... 0.1, 0.2, 0.5, 1, 2, 5, 10, 20, ...⟩
   | Constant (Real c) -> Regex.IsMatch($"%.15e{c}", "^[125]\.0+e[-+]\d+$")
@@ -433,7 +433,7 @@ let private untrustedAllowsRange arg =
 let private validateBucketLabelExpression accessLevel expression =
   if accessLevel = PublishUntrusted then
     match expression with
-    | FunctionExpr (ScalarFunction FloorBy, [ _; arg ]) when untrustedAllowsRange arg -> ()
+    | FunctionExpr (ScalarFunction FloorBy, [ _; arg ]) when isMoneyStyle arg -> ()
     | FunctionExpr (ScalarFunction Substring, [ _; fromArg; _ ]) when fromArg = (1L |> Integer |> Constant) -> ()
     | _ -> failwith "Generalization used in the query is not allowed in untrusted access level"
 


### PR DESCRIPTION
This is just a small fixup of #328. This adds a test that `ceil` and `round` behave as expected in untrusted analyst mode. Also smuggles a rename of a function, whose name I found very confusing on second visit.

EDIT: after discussion, it turned out that we actually want to admit `ceil` and `round`. While doing so, I found that non-generalized queries were invalidly blocked, so fixed that as well.