### PR TITLE
Move data anonymization to leaf subqueries.

### DIFF
--- a/src/OpenDiffix.CLI/JsonEncodersDecoders.fs
+++ b/src/OpenDiffix.CLI/JsonEncodersDecoders.fs
@@ -21,7 +21,7 @@ module private rec Encoders =
     | String string -> Encode.string string
     | List values -> Encode.list (values |> List.map encodeValue)
 
-  let rec private typeName =
+  let private typeName =
     function
     | BooleanType -> "boolean"
     | IntegerType -> "integer"

--- a/src/OpenDiffix.CLI/JsonEncodersDecoders.fs
+++ b/src/OpenDiffix.CLI/JsonEncodersDecoders.fs
@@ -27,7 +27,6 @@ module private rec Encoders =
     | IntegerType -> "integer"
     | RealType -> "real"
     | StringType -> "text"
-    | ListType itemType -> typeName itemType + "[]"
     | UnknownType _ -> "unknown"
 
   let private encodeType = typeName >> Encode.string

--- a/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
@@ -29,6 +29,7 @@ let defaultQuery =
     Having = Boolean true |> Constant
     OrderBy = []
     Limit = None
+    AnonymizationContext = None
   }
 
 let testParsedQuery queryString expected =
@@ -159,6 +160,7 @@ let ``SELECT with alias, function, aggregate, GROUP BY, and WHERE-clause`` () =
         )
       OrderBy = []
       Limit = None
+      AnonymizationContext = None
     }
 
 [<Fact>]
@@ -294,7 +296,6 @@ type Tests(db: DBFixture) =
     |> Analyzer.analyze (queryContext accessLevel)
     |> Normalizer.normalize
     |> Analyzer.anonymize (queryContext accessLevel)
-    |> fst
 
   let analyzeTrustedQuery = analyzeQuery PublishTrusted
   let analyzeDirectQuery = analyzeQuery Direct
@@ -311,23 +312,19 @@ type Tests(db: DBFixture) =
   let assertDirectQueryFails = assertQueryFails Direct
   let assertUntrustedQueryFails = assertQueryFails PublishUntrusted
 
-  let sqlNoiseLayers query =
-    query
-    |> Parser.parse
-    |> Analyzer.analyze (queryContext PublishTrusted)
-    |> Normalizer.normalize
-    |> Analyzer.anonymize (queryContext PublishTrusted)
-    |> snd
-
   let assertSqlSeed query (seedMaterials: string seq) =
     let expectedSeed = Hash.strings 0UL seedMaterials
-    (sqlNoiseLayers query).BucketSeed |> should equal expectedSeed
 
-  let assertDefaultSqlSeed query =
-    (sqlNoiseLayers query) |> should equal NoiseLayers.Default
+    (analyzeTrustedQuery query).AnonymizationContext
+    |> Option.contains { BucketSeed = expectedSeed }
+    |> should equal true
 
-  let assertNoLCF query =
-    (analyzeTrustedQuery query).Having |> should equal (Boolean true |> Constant)
+  let assertEqualAnonContexts query1 query2 =
+    (analyzeTrustedQuery query1).AnonymizationContext
+    |> should equal (analyzeTrustedQuery query2).AnonymizationContext
+
+  let assertNoAnonContext query =
+    (analyzeTrustedQuery query).AnonymizationContext |> should equal None
 
   [<Fact>]
   let ``Analyze count transforms`` () =
@@ -445,8 +442,8 @@ type Tests(db: DBFixture) =
 
   [<Fact>]
   let ``Default SQL seed from non-anonymizing queries`` () =
-    assertDefaultSqlSeed "SELECT * FROM products"
-    assertDefaultSqlSeed "SELECT count(*) FROM products"
+    assertNoAnonContext "SELECT * FROM products"
+    assertNoAnonContext "SELECT count(*) FROM products"
 
   [<Fact>]
   let ``SQL seed from non-anonymizing queries using anonymizing aggregates`` () =
@@ -463,14 +460,16 @@ type Tests(db: DBFixture) =
   [<Fact>]
   let ``SQL seeds from numeric ranges are consistent`` () =
     // TODO: temporarily broken, because `floor(age)` seeds as `age` and `floor_by(cast(...), 1.0)` seeds as `floor,age,1.0`
-    // (sqlNoiseLayers "SELECT floor(age) FROM customers_small GROUP BY 1")
-    // |> should equal (sqlNoiseLayers "SELECT floor_by(cast(age AS real), 1.0) FROM customers_small GROUP BY 1")
+    // assertEqualAnonContexts
+    //  "SELECT floor(age) FROM customers_small GROUP BY 1"
+    //  "SELECT floor_by(cast(age AS real), 1.0) FROM customers_small GROUP BY 1"
+    // assertEqualAnonContexts
+    //  "SELECT round(cast(age AS real)) FROM customers_small GROUP BY 1"
+    //  "SELECT round_by(age, 1.0) FROM customers_small GROUP BY 1"
 
-    // (sqlNoiseLayers "SELECT round(cast(age AS real)) FROM customers_small GROUP BY 1")
-    // |> should equal (sqlNoiseLayers "SELECT round_by(age, 1.0) FROM customers_small GROUP BY 1")
-
-    (sqlNoiseLayers "SELECT ceil_by(age, 1.0) FROM customers_small GROUP BY 1")
-    |> should equal (sqlNoiseLayers "SELECT ceil_by(age, 1) FROM customers_small GROUP BY 1")
+    assertEqualAnonContexts
+      "SELECT ceil_by(age, 1.0) FROM customers_small GROUP BY 1"
+      "SELECT ceil_by(age, 1) FROM customers_small GROUP BY 1"
 
   [<Fact>]
   let ``SQL seed from rounding cast`` () =
@@ -478,26 +477,26 @@ type Tests(db: DBFixture) =
 
   [<Fact>]
   let ``Default SQL seed from non-anonymizing rounding cast`` () =
-    assertDefaultSqlSeed "SELECT cast(price AS integer) FROM products"
+    assertNoAnonContext "SELECT cast(price AS integer) FROM products"
 
   [<Fact>]
   let ``Constant bucket labels are ignored`` () =
-    (analyzeTrustedQuery "SELECT age, round(1) FROM customers_small GROUP BY 1, 2")
-    |> should equal (analyzeTrustedQuery "SELECT age, round(1) FROM customers_small GROUP BY 1")
+    assertEqualAnonContexts
+      "SELECT age, round(1) FROM customers_small GROUP BY 1, 2"
+      "SELECT age, round(1) FROM customers_small GROUP BY 1"
 
-    (analyzeTrustedQuery "SELECT 1, COUNT(*) FROM customers_small GROUP BY 1")
-    |> should equal (analyzeTrustedQuery "SELECT 1, COUNT(*) FROM customers_small")
+    assertEqualAnonContexts
+      "SELECT 1, COUNT(*) FROM customers_small GROUP BY 1"
+      "SELECT 1, COUNT(*) FROM customers_small"
 
   [<Fact>]
   let ``Constants targets aren't used for implicit bucket grouping and don't impact the seed`` () =
-    (sqlNoiseLayers "SELECT round(1) FROM customers_small")
-    |> should equal (sqlNoiseLayers "SELECT round(2) FROM customers_small")
-
-    (sqlNoiseLayers "SELECT age, round(1) FROM customers_small")
-    |> should equal (sqlNoiseLayers "SELECT age, round(2) FROM customers_small")
+    assertEqualAnonContexts "SELECT round(1) FROM customers_small" "SELECT round(2) FROM customers_small"
+    assertEqualAnonContexts "SELECT age, round(1) FROM customers_small" "SELECT age, round(2) FROM customers_small"
 
   [<Fact>]
   let ``No low-count filtering for non-grouping, non-aggregate queries with only constants`` () =
-    assertNoLCF "SELECT round(1) FROM customers_small"
+    (analyzeTrustedQuery "SELECT round(1) FROM customers_small").Having
+    |> should equal (Boolean true |> Constant)
 
   interface IClassFixture<DBFixture>

--- a/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
@@ -378,11 +378,15 @@ type Tests(db: DBFixture) =
     analyzeTrustedQuery "SELECT count(city) FROM (SELECT city FROM customers) x"
 
   [<Fact>]
-  let ``Allow limiting top query`` () =
+  let ``Allow LIMIT clause in anonymizing subqueries`` () =
     analyzeTrustedQuery "SELECT count(*) FROM customers LIMIT 1"
 
   [<Fact>]
-  let ``Disallow anonymizing queries with WHERE`` () =
+  let ``Allow HAVING clause in anonymizing subqueries`` () =
+    analyzeTrustedQuery "SELECT count(*) FROM customers GROUP BY city HAVING length(city) > 3"
+
+  [<Fact>]
+  let ``Reject WHERE clause in anonymizing subqueries`` () =
     assertTrustedQueryFails
       "SELECT count(*) FROM customers WHERE first_name=''"
       "WHERE in anonymizing queries is not currently supported."

--- a/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
@@ -316,8 +316,7 @@ type Tests(db: DBFixture) =
     let expectedSeed = Hash.strings 0UL seedMaterials
 
     (analyzeTrustedQuery query).AnonymizationContext
-    |> Option.contains { BucketSeed = expectedSeed }
-    |> should equal true
+    |> should equal (Some { BucketSeed = expectedSeed })
 
   let assertEqualAnonContexts query1 query2 =
     (analyzeTrustedQuery query1).AnonymizationContext

--- a/src/OpenDiffix.Core.Tests/Anonymizer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Anonymizer.Tests.fs
@@ -41,31 +41,9 @@ let aggContext = { AnonymizationParams = anonParams; GroupingLabels = [||]; Aggr
 let evaluateAggregator fn args =
   evaluateAggregator (aggContext, Some { BucketSeed = 0UL }) fn args
 
-let mergeAids = MergeAids, AggregateOptions.Default
 let distinctDiffixCount = DiffixCount, { AggregateOptions.Default with Distinct = true }
 let diffixCount = DiffixCount, { AggregateOptions.Default with Distinct = false }
 let diffixLowCount = DiffixLowCount, AggregateOptions.Default
-
-[<Fact>]
-let ``merge bucket aids`` () =
-  rows
-  |> evaluateAggregator mergeAids [ aidColumn ]
-  |> (function
-  | Value.List values -> Value.List(List.sort values)
-  | x -> x)
-  |> should
-       equal
-       (Value.List [
-         Integer 1L
-         Integer 2L
-         Integer 3L
-         Integer 4L
-         Integer 5L
-         Integer 6L
-         Integer 7L
-         Integer 8L
-         Integer 9L
-        ])
 
 [<Fact>]
 let ``anon count distinct column`` () =
@@ -300,78 +278,6 @@ let ``account for values where AID-value is null`` () =
   rows
   |> evaluateAggregator diffixCount [ allAidColumns; value ]
   |> should equal (Integer 8L)
-
-[<Fact>]
-let ``low count accepts rows with shared contribution`` () =
-  let aidList names = names |> List.map String |> Value.List
-  let aidsExpression = ListExpr [ ColumnReference(0, ListType StringType) ]
-
-  let lowUserRows = [ [| aidList [ "Sebastian" ] |] ]
-  let highUserRows = [ [| aidList [ "Paul"; "Cristian"; "Felix"; "Edon" ] |] ]
-
-  lowUserRows
-  |> evaluateAggregator diffixLowCount [ aidsExpression ]
-  |> should equal (Boolean true)
-
-  highUserRows
-  |> evaluateAggregator diffixLowCount [ aidsExpression ]
-  |> should equal (Boolean false)
-
-[<Fact>]
-let ``count accepts rows with shared contribution`` () =
-  let aidList names = names |> List.map String |> Value.List
-  let aidsExpression = ListExpr [ ColumnReference(0, ListType StringType) ]
-
-  let rows =
-    [
-      // AIDs
-      [| aidList [ "Paul"; "Felix"; "Edon" ] |]
-      [| aidList [ "Paul"; "Felix"; "Edon" ] |]
-      [| aidList [ "Sebastian"; "Felix"; "Edon" ] |]
-      [| aidList [ "Paul"; "Cristian" ] |]
-      [| aidList [ "Cristian" ] |]
-      [| aidList [ "Cristian" ] |]
-      [| aidList [ "Cristian" ] |]
-    ]
-
-  // Cristian:  1/2 + 1 + 1 + 1 = 3.5  (outlier)
-  // Paul:      1/3 + 1/3 + 1/2 = 1.16 (top)
-  // Felix:     1/3 + 1/3 + 1/3 = 1.0
-  // Edon:      1/3 + 1/3 + 1/3 = 1.0
-  // Sebastian: 1/3             = 0.33
-  // Total:                     = 7.0
-
-  rows
-  |> evaluateAggregator diffixCount [ aidsExpression ]
-  |> should equal (Integer 5L)
-
-[<Fact>]
-let ``count distinct accepts rows with shared contribution`` () =
-  let email values = values |> List.map String |> Value.List
-  let firstName = email
-
-  let aidsExpression = ListExpr [ ColumnReference(0, ListType StringType); ColumnReference(1, ListType StringType) ]
-  let dataColumn = ColumnReference(2, StringType)
-
-  // See `docs/distinct pre-processing.md` for explanation.
-  let rows =
-    [
-      [| email [ "Paul"; "Sebastian" ]; firstName [ "Sebastian" ]; String "Apple" |]
-      [| email [ "Paul"; "Edon" ]; firstName [ "Sebastian" ]; String "Apple" |]
-      [| email [ "Sebastian" ]; firstName [ "Sebastian" ]; String "Apple" |]
-      [| email [ "Cristian" ]; firstName [ "Paul" ]; String "Apple" |]
-      [| email [ "Edon" ]; firstName [ "Paul" ]; String "Apple" |]
-      [| email [ "Edon" ]; firstName [ "Paul" ]; String "Pear" |]
-      [| email [ "Paul" ]; firstName [ "Paul" ]; String "Pineapple" |]
-      [| email [ "Cristian" ]; firstName [ "Paul" ]; String "Lemon" |]
-      [| email [ "Cristian" ]; firstName [ "Felix" ]; String "Orange" |]
-      [| email [ "Felix" ]; firstName [ "Edon" ]; String "Banana" |]
-      [| email [ "Edon" ]; firstName [ "Cristian" ]; String "Grapefruit" |]
-    ]
-
-  rows
-  |> evaluateAggregator distinctDiffixCount [ aidsExpression; dataColumn ]
-  |> should equal (Integer 5L)
 
 [<Fact>]
 let ``compacting top/outlier interval respects rules`` () =

--- a/src/OpenDiffix.Core.Tests/Expression.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Expression.Tests.fs
@@ -535,8 +535,15 @@ let colRef2 = ColumnReference(2, RealType)
 
 let evaluate expr = Expression.evaluate testRow expr
 
+let aggContext =
+  {
+    AnonymizationParams = AnonymizationParams.Default
+    GroupingLabels = [||]
+    Aggregators = [||]
+  }
+
 let evaluateAggregator aggSpec args =
-  evaluateAggregator (ExecutionContext.makeDefault ()) aggSpec args testRows
+  evaluateAggregator (aggContext, Some { BucketSeed = 0UL }) aggSpec args testRows
 
 [<Fact>]
 let ``evaluate scalar expressions`` () =

--- a/src/OpenDiffix.Core.Tests/NodeUtils.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/NodeUtils.Tests.fs
@@ -29,6 +29,7 @@ let selectQuery =
     Having = expression
     OrderBy = [ OrderBy(expression, Ascending, NullsFirst) ]
     Limit = None
+    AnonymizationContext = Some { BucketSeed = 0UL }
   }
 
 let selectQueryNegative =
@@ -40,6 +41,7 @@ let selectQueryNegative =
     Having = negativeExpression
     OrderBy = [ OrderBy(negativeExpression, Ascending, NullsFirst) ]
     Limit = None
+    AnonymizationContext = Some { BucketSeed = 0UL }
   }
 
 [<Fact>]

--- a/src/OpenDiffix.Core.Tests/Planner.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Planner.Tests.fs
@@ -26,6 +26,7 @@ let emptySelect =
     Having = constTrue
     OrderBy = []
     Limit = None
+    AnonymizationContext = Some { BucketSeed = 0UL }
   }
 
 let column index =
@@ -82,7 +83,7 @@ let ``plan aggregation`` () =
 
   let expected =
     Plan.Project(
-      Plan.Aggregate(Plan.Scan(table, [ 1 ]), groupBy, [ countStar ]),
+      Plan.Aggregate(Plan.Scan(table, [ 1 ]), groupBy, [ countStar ], emptySelect.AnonymizationContext),
       [ ColumnReference(0, StringType); ColumnReference(1, IntegerType) ]
     )
 
@@ -96,7 +97,10 @@ let ``plan aggregation without selection`` () =
   let select = { emptySelect with TargetList = selectedColumns; GroupBy = groupBy }
 
   let expected =
-    Plan.Project(Plan.Aggregate(Plan.Scan(table, [ 1 ]), groupBy, [ countStar ]), [ ColumnReference(1, IntegerType) ])
+    Plan.Project(
+      Plan.Aggregate(Plan.Scan(table, [ 1 ]), groupBy, [ countStar ], emptySelect.AnonymizationContext),
+      [ ColumnReference(1, IntegerType) ]
+    )
 
   select |> Planner.plan |> should equal expected
 
@@ -133,7 +137,8 @@ let ``plan all`` () =
               whereCondition
             ),
             groupBy,
-            [ countStar ]
+            [ countStar ],
+            emptySelect.AnonymizationContext
           ),
           FunctionExpr(ScalarFunction Equals, [ ColumnReference(1, IntegerType); Constant(Integer 0L) ])
         ),

--- a/src/OpenDiffix.Core.Tests/TestHelpers.fs
+++ b/src/OpenDiffix.Core.Tests/TestHelpers.fs
@@ -6,7 +6,7 @@ type DBFixture() =
     new OpenDiffix.CLI.SQLite.DataProvider(__SOURCE_DIRECTORY__ + "/../../data/data.sqlite") :> IDataProvider
 
 let evaluateAggregator ctx aggSpec args rows =
-  let aggregator = Aggregator.create ctx true aggSpec
+  let aggregator = Aggregator.create aggSpec
   let processor = fun row -> args |> List.map (Expression.evaluate row) |> aggregator.Transition
   List.iter processor rows
   aggregator.Final ctx

--- a/src/OpenDiffix.Core/Aggregator.fs
+++ b/src/OpenDiffix.Core/Aggregator.fs
@@ -284,24 +284,6 @@ type private DiffixLowCount() =
       else
         Boolean(Anonymizer.isLowCount aggContext.AnonymizationParams anonContext state)
 
-type private MergeAids() =
-  let state = HashSet<Value>()
-
-  member this.State = state
-
-  interface IAggregator with
-    member this.Transition args =
-      match args with
-      | [ Null ] -> ()
-      | [ Value.List aidValues ] -> state.UnionWith(aidValues)
-      | [ aidValue ] -> state.Add(aidValue) |> ignore
-      | _ -> invalidArgs args
-
-    member this.Merge aggregator =
-      state.UnionWith((castAggregator<MergeAids> aggregator).State)
-
-    member this.Final(_anonParams, _anonContext) = state |> Seq.toList |> Value.List
-
 // ----------------------------------------------------------------
 // Public API
 // ----------------------------------------------------------------
@@ -322,5 +304,4 @@ let create (aggSpec: AggregatorSpec) : T =
   | DiffixCount, { Distinct = false } -> DiffixCount() :> T
   | DiffixCount, { Distinct = true } -> DiffixCountDistinct() :> T
   | DiffixLowCount, _ -> DiffixLowCount() :> T
-  | MergeAids, _ -> MergeAids() :> T
   | _ -> failwith "Invalid aggregator"

--- a/src/OpenDiffix.Core/Analyzer.fs
+++ b/src/OpenDiffix.Core/Analyzer.fs
@@ -246,33 +246,8 @@ let private mapQuery schema anonParams isSubQuery (selectQuery: ParserTypes.Sele
     |> mapOrderByIndices targetList
     |> List.map (fun (expression, direction, nullsBehavior) -> OrderBy(expression, direction, nullsBehavior))
 
-  let isAggregating = not (List.isEmpty groupBy && List.isEmpty (collectAggregates targetList))
-
-  let aidTargets =
-    if isSubQuery then
-      // Subqueries will export their AIDs to outer queries.
-      rangeColumns
-      |> List.indexed
-      |> List.filter (fun (_i, col) -> col.IsAid)
-      |> List.mapi (fun aidIndex (colIndex, col) ->
-        {
-          Expression =
-            if isAggregating then
-              FunctionExpr(
-                AggregateFunction(MergeAids, AggregateOptions.Default),
-                [ ColumnReference(colIndex, col.Type) ]
-              )
-            else
-              ColumnReference(colIndex, col.Type)
-          Alias = $"__aid_{aidIndex}"
-          Tag = AidTargetEntry
-        }
-      )
-    else
-      []
-
   {
-    TargetList = targetList @ aidTargets
+    TargetList = targetList
     Where = whereClause
     From = range
     GroupBy = groupBy
@@ -359,20 +334,35 @@ let private compileAnonymizingQuery aidColumnsExpression selectQuery =
 
   { selectQuery with GroupBy = groupBy; Having = having }
 
-let private compileQuery anonParams (selectQuery: SelectQuery) =
-  let rangeColumns = collectRangeColumns anonParams selectQuery.From
+let private compileQuery anonParams (query: SelectQuery) =
+  let rangeColumns = collectRangeColumns anonParams query.From
   let aidColumnsExpression = makeAidColumnsExpression rangeColumns
 
   let isAnonymizing =
     anonParams.AccessLevel <> Direct
     && aidColumnsExpression |> Expression.unwrapListExpr |> List.isEmpty |> not
 
-  if isAnonymizing then
-    QueryValidator.validateAnonymizingQuery selectQuery
-    compileAnonymizingQuery aidColumnsExpression selectQuery
+  let query =
+    if isAnonymizing then
+      QueryValidator.validateAnonymizingQuery query
+      compileAnonymizingQuery aidColumnsExpression query
+    else
+      QueryValidator.validateDirectQuery query
+      query
+
+  // Noise seeding is needed only for anonymizing aggregators. This includes the aggregators injected
+  // in `compileAnonymizingQuery` and explicit use of noisy aggregators like `diffix_low_count`.
+  // If there aren't any, we also don't need to do the validations which are done deep in `computeSQLSeed`.
+  if hasAnonymizingAggregators query then
+    let rangeColumns = collectRangeColumns anonParams query.From
+    let normalizedBucketLabelExpressions = query.GroupBy |> Seq.map (normalizeBucketLabelExpression)
+
+    QueryValidator.validateGeneralizations anonParams.AccessLevel normalizedBucketLabelExpressions
+    let sqlSeed = NoiseLayers.computeSQLSeed rangeColumns normalizedBucketLabelExpressions
+    { query with AnonymizationContext = Some { BucketSeed = sqlSeed } }
   else
-    QueryValidator.validateDirectQuery selectQuery
-    selectQuery
+    query
+
 
 let rec private normalizeBucketLabelExpression expression =
   match expression with
@@ -400,19 +390,7 @@ let analyze queryContext (parseTree: ParserTypes.SelectQuery) : Query =
   let query = mapQuery schema anonParams false parseTree
   query
 
-let anonymize (queryContext: QueryContext) (query: Query) =
-  let anonParams = queryContext.AnonymizationParams
-  let query = compileQuery anonParams query
-
-  // Noise is needed only when we anonymize. If we don't, we also don't need to do the validations which are done deep
-  // in `computeNoiseLayers`. This includes anonymization injected in `compileQuery` and explicit use of anonymizing
-  // aggregates like `diffix_low_count`.
-  if hasAnonymizingAggregators query then
-    let rangeColumns = collectRangeColumns anonParams query.From
-    let normalizedBucketLabelExpressions = query.GroupBy |> Seq.map (normalizeBucketLabelExpression)
-
-    QueryValidator.validateGeneralizations anonParams.AccessLevel normalizedBucketLabelExpressions
-    let sqlSeed = NoiseLayers.computeSQLSeed rangeColumns normalizedBucketLabelExpressions
-    { query with AnonymizationContext = Some { BucketSeed = sqlSeed } }
-  else
-    query
+let rec compile (queryContext: QueryContext) (query: Query) =
+  query
+  |> map (compile queryContext)
+  |> compileQuery queryContext.AnonymizationParams

--- a/src/OpenDiffix.Core/AnalyzerTypes.fs
+++ b/src/OpenDiffix.Core/AnalyzerTypes.fs
@@ -15,6 +15,7 @@ type SelectQuery =
     OrderBy: OrderBy list
     Having: Expression
     Limit: uint option
+    AnonymizationContext: AnonymizationContext option
   }
 
 type TargetEntry = { Expression: Expression; Alias: string; Tag: TargetEntryTag }

--- a/src/OpenDiffix.Core/CommonTypes.fs
+++ b/src/OpenDiffix.Core/CommonTypes.fs
@@ -172,7 +172,7 @@ type AnonymizationParams =
 // Query & Planner
 // ----------------------------------------------------------------
 
-type PostAggregationHook = AggregationContext -> seq<Bucket> -> seq<Bucket>
+type PostAggregationHook = AggregationContext -> AnonymizationContext -> seq<Bucket> -> seq<Bucket>
 
 type QueryContext =
   {
@@ -194,7 +194,7 @@ type Plan =
   | ProjectSet of Plan * setGenerator: SetFunction * args: Expression list
   | Filter of Plan * condition: Expression
   | Sort of Plan * OrderBy list
-  | Aggregate of Plan * groupingLabels: Expression list * aggregators: Expression list
+  | Aggregate of Plan * groupingLabels: Expression list * aggregators: Expression list * AnonymizationContext option
   | Unique of Plan
   | Join of left: Plan * right: Plan * JoinType * on: Expression
   | Append of first: Plan * second: Plan
@@ -205,19 +205,14 @@ type Plan =
 // Executor
 // ----------------------------------------------------------------
 
-type NoiseLayers =
-  {
-    BucketSeed: Hash
-  }
-  static member Default = { BucketSeed = 0UL }
+type AnonymizationContext = { BucketSeed: Hash }
 
-type ExecutionContext =
+type AggregationContext =
   {
-    QueryContext: QueryContext
-    NoiseLayers: NoiseLayers
+    AnonymizationParams: AnonymizationParams
+    GroupingLabels: Expression array
+    Aggregators: (AggregatorSpec * AggregatorArgs) array
   }
-  member this.AnonymizationParams = this.QueryContext.AnonymizationParams
-  member this.DataProvider = this.QueryContext.DataProvider
 
 // Responsible for accumulating the state of the aggregation function while
 // scanning the rows, and delivering the final result as a query result `Value`
@@ -228,24 +223,17 @@ type IAggregator =
   // Merge state with that of a compatible aggregator
   abstract Merge : IAggregator -> unit
   // Extract the final value of the aggregation function from the state
-  abstract Final : ExecutionContext -> Value
+  abstract Final : AggregationContext * AnonymizationContext option -> Value
 
 type AggregatorSpec = AggregateFunction * AggregateOptions
 type AggregatorArgs = Expression list
-
-type AggregationContext =
-  {
-    ExecutionContext: ExecutionContext
-    GroupingLabels: Expression array
-    Aggregators: (AggregatorSpec * AggregatorArgs) array
-  }
 
 type Bucket =
   {
     Group: Row
     mutable RowCount: int
     Aggregators: IAggregator array
-    ExecutionContext: ExecutionContext
+    AnonymizationContext: AnonymizationContext option
     Attributes: Dictionary<string, Value>
   }
 
@@ -412,13 +400,6 @@ module QueryContext =
   let makeWithDataProvider dataProvider =
     make AnonymizationParams.Default dataProvider
 
-module ExecutionContext =
-  let fromQueryContext queryContext =
-    { QueryContext = queryContext; NoiseLayers = NoiseLayers.Default }
-
-  let makeDefault () =
-    fromQueryContext (QueryContext.makeDefault ())
-
 module Plan =
   let rec columnsCount (plan: Plan) =
     match plan with
@@ -427,7 +408,7 @@ module Plan =
     | Plan.ProjectSet (plan, _, _) -> (columnsCount plan) + 1
     | Plan.Filter (plan, _) -> columnsCount plan
     | Plan.Sort (plan, _) -> columnsCount plan
-    | Plan.Aggregate (_, groupingLabels, aggregators) -> groupingLabels.Length + aggregators.Length
+    | Plan.Aggregate (_, groupingLabels, aggregators, _) -> groupingLabels.Length + aggregators.Length
     | Plan.Unique plan -> columnsCount plan
     | Plan.Join (left, right, _, _) -> columnsCount left + columnsCount right
     | Plan.Append (first, _) -> columnsCount first
@@ -456,10 +437,11 @@ module Plan =
         $"ProjectSet {fn}({String.joinWithComma args})" + childToString childPlan
       | Plan.Filter (childPlan, condition) -> $"Filter {condition})" + childToString childPlan
       | Plan.Sort (childPlan, orderings) -> $"Sort {String.joinWithComma orderings}" + childToString childPlan
-      | Plan.Aggregate (childPlan, groupingLabels, aggregators) ->
+      | Plan.Aggregate (childPlan, groupingLabels, aggregators, anonymizationContext) ->
         "Aggregate"
         + $"{propLine depth}Group Keys: {String.joinWithComma groupingLabels}"
         + $"{propLine depth}Aggregates: {String.joinWithComma aggregators}"
+        + $"{propLine depth}AnonymizationContext: {anonymizationContext}"
         + childToString childPlan
       | Plan.Unique childPlan -> "Unique" + childToString childPlan
       | Plan.Join (leftPlan, rightPlan, joinType, condition) ->

--- a/src/OpenDiffix.Core/CommonTypes.fs
+++ b/src/OpenDiffix.Core/CommonTypes.fs
@@ -27,7 +27,6 @@ type ExpressionType =
   | IntegerType
   | RealType
   | StringType
-  | ListType of ExpressionType
   | UnknownType of string
 
 type Expression =
@@ -81,7 +80,6 @@ type AggregateFunction =
   | DiffixCount
   | DiffixLowCount
   | Sum
-  | MergeAids
 
 type AggregateOptions =
   {

--- a/src/OpenDiffix.Core/Expression.fs
+++ b/src/OpenDiffix.Core/Expression.fs
@@ -66,11 +66,7 @@ let typeOfAggregate fn args =
   | Count
   | DiffixCount -> IntegerType
   | DiffixLowCount -> BooleanType
-  | Sum ->
-    match typeOfList args with
-    | ListType IntegerType -> IntegerType
-    | _ -> RealType
-  | MergeAids -> ListType MIXED_TYPE
+  | Sum -> RealType
 
 /// Resolves the type of an expression.
 let rec typeOf expression =

--- a/src/OpenDiffix.Core/Led.fs
+++ b/src/OpenDiffix.Core/Led.fs
@@ -140,7 +140,7 @@ let private prepareBuckets (aggregationContext: AggregationContext) (buckets: Bu
   let victimBuckets =
     buckets
     |> Array.Parallel.choose (fun bucket ->
-      let lowCount = Bucket.isLowCount lowCountIndex bucket
+      let lowCount = Bucket.isLowCount lowCountIndex bucket aggregationContext
       let bucketTuple = bucket, lowCount
       let columnValues = bucket.Group
       let siblingsPerColumn = Array.zeroCreate<SiblingsPerColumn> groupingLabelsLength
@@ -227,7 +227,7 @@ let private led (aggregationContext: AggregationContext) (buckets: Bucket array)
 // Public API
 // ----------------------------------------------------------------
 
-let hook (aggregationContext: AggregationContext) (buckets: Bucket seq) =
+let hook (aggregationContext: AggregationContext) (_anonymizationContext: AnonymizationContext) (buckets: Bucket seq) =
   let stopwatch = startStopwatch ()
 
   try

--- a/src/OpenDiffix.Core/NodeUtils.fs
+++ b/src/OpenDiffix.Core/NodeUtils.fs
@@ -36,6 +36,7 @@ type NodeFunctions =
       OrderBy = NodeFunctions.Map(query.OrderBy, f)
       Having = f query.Having
       Limit = query.Limit
+      AnonymizationContext = query.AnonymizationContext
     }
 
   // TargetEntry

--- a/src/OpenDiffix.Core/NoiseLayers.fs
+++ b/src/OpenDiffix.Core/NoiseLayers.fs
@@ -33,10 +33,7 @@ let private collectSeedMaterials rangeColumns expression =
 // Public API
 // ----------------------------------------------------------------
 
-let computeSQLLayer rangeColumns normalizedBucketLabelExpressions =
-  let sqlSeed =
-    normalizedBucketLabelExpressions
-    |> Seq.map (collectSeedMaterials rangeColumns)
-    |> Hash.strings 0UL
-
-  { BucketSeed = sqlSeed }
+let computeSQLSeed rangeColumns normalizedBucketLabelExpressions =
+  normalizedBucketLabelExpressions
+  |> Seq.map (collectSeedMaterials rangeColumns)
+  |> Hash.strings 0UL

--- a/src/OpenDiffix.Core/Parser.fs
+++ b/src/OpenDiffix.Core/Parser.fs
@@ -152,38 +152,38 @@ module QueryParser =
           List.fold (fun left ((joinType, right), on) -> Join(joinType, left, right, on)) first_table joined_tables
 
   do
-    selectQueryRef
-    := word "SELECT"
-       >>= fun _ ->
-             distinct
-             >>= fun distinct ->
-                   commaSepExpressions
-                   >>= fun columns ->
-                         from
-                         >>= fun from ->
-                               opt whereClause
-                               >>= fun whereClause ->
-                                     opt groupBy
-                                     >>= fun groupBy ->
-                                           opt havingClause
-                                           >>= fun having ->
-                                                 opt orderBy
-                                                 >>= fun orderBy ->
-                                                       opt limitClause
-                                                       >>= fun limit ->
-                                                             let query =
-                                                               {
-                                                                 SelectDistinct = distinct
-                                                                 Expressions = columns
-                                                                 From = from
-                                                                 Where = whereClause
-                                                                 GroupBy = groupBy |> Option.defaultValue []
-                                                                 Having = having
-                                                                 Limit = limit
-                                                                 OrderBy = orderBy |> Option.defaultValue []
-                                                               }
+    selectQueryRef.Value <-
+      word "SELECT"
+      >>= fun _ ->
+            distinct
+            >>= fun distinct ->
+                  commaSepExpressions
+                  >>= fun columns ->
+                        from
+                        >>= fun from ->
+                              opt whereClause
+                              >>= fun whereClause ->
+                                    opt groupBy
+                                    >>= fun groupBy ->
+                                          opt havingClause
+                                          >>= fun having ->
+                                                opt orderBy
+                                                >>= fun orderBy ->
+                                                      opt limitClause
+                                                      >>= fun limit ->
+                                                            let query =
+                                                              {
+                                                                SelectDistinct = distinct
+                                                                Expressions = columns
+                                                                From = from
+                                                                Where = whereClause
+                                                                GroupBy = groupBy |> Option.defaultValue []
+                                                                Having = having
+                                                                Limit = limit
+                                                                OrderBy = orderBy |> Option.defaultValue []
+                                                              }
 
-                                                             preturn (Expression.SelectQuery query)
+                                                            preturn (Expression.SelectQuery query)
 
   // This is sort of silly... but the operator precedence parser is case sensitive. This means
   // if we add a parser for AND, then it will fail if you write a query as And... Therefore

--- a/src/OpenDiffix.Core/QueryEngine.fs
+++ b/src/OpenDiffix.Core/QueryEngine.fs
@@ -48,7 +48,7 @@ let run queryContext statement : QueryResult =
     |> Parser.parse
     |> Analyzer.analyze queryContext
     |> Normalizer.normalize
-    |> Analyzer.anonymize queryContext
+    |> Analyzer.compile queryContext
 
   let rows = query |> Planner.plan |> Executor.execute queryContext |> Seq.toList
   let columns = extractColumns query

--- a/src/OpenDiffix.Core/QueryEngine.fs
+++ b/src/OpenDiffix.Core/QueryEngine.fs
@@ -43,15 +43,13 @@ type QueryResult = { Columns: Column list; Rows: Row list }
 //
 // `aid_columns_expression` should be a list of `aid_column` or `DISTINCT aid_column`.
 let run queryContext statement : QueryResult =
-  let query, noiseLayers =
+  let query =
     statement
     |> Parser.parse
     |> Analyzer.analyze queryContext
     |> Normalizer.normalize
     |> Analyzer.anonymize queryContext
 
-  let executionContext = { QueryContext = queryContext; NoiseLayers = noiseLayers }
-
-  let rows = query |> Planner.plan |> Executor.execute executionContext |> Seq.toList
+  let rows = query |> Planner.plan |> Executor.execute queryContext |> Seq.toList
   let columns = extractColumns query
   { Columns = columns; Rows = rows }

--- a/src/OpenDiffix.Core/QueryValidator.fs
+++ b/src/OpenDiffix.Core/QueryValidator.fs
@@ -23,14 +23,15 @@ let private validateSingleLowCount query =
     |> List.distinct
 
   if List.length lowCountAggregators > 1 then
-    failwith "A single low count aggregator is allowed in a query"
+    failwith "A single low count aggregator is allowed in a query."
 
 let private validateOnlyCount query =
   query
   |> visitAggregates (
     function
     | FunctionExpr (AggregateFunction (Count, _), _) -> ()
-    | FunctionExpr (AggregateFunction (_otherAggregate, _), _) -> failwith "Only count aggregates are supported"
+    | FunctionExpr (AggregateFunction (_otherAggregate, _), _) ->
+      failwith "Only count aggregates are supported in anonymizing queries."
     | _ -> ()
   )
 
@@ -42,19 +43,19 @@ let private allowedCountUsage query =
       match args with
       | []
       | [ ColumnReference _ ] -> ()
-      | _ -> failwith "Only count(*), count(column) and count(distinct column) are supported"
+      | _ -> failwith "Only count(*), count(column) and count(distinct column) are supported in anonymizing queries."
     | _ -> ()
   )
 
 let private validateSelectTarget (selectQuery: SelectQuery) =
   match selectQuery.From with
-  | Join _ -> failwith "JOIN in anonymizing queries is not currently supported"
-  | SubQuery _ -> failwith "Subqueries in anonymizing queries are not currently supported"
+  | Join _ -> failwith "JOIN in anonymizing queries is not currently supported."
+  | SubQuery _ -> failwith "Subqueries in anonymizing queries are not currently supported."
   | _ -> ()
 
 let private validateNoWhere (selectQuery: SelectQuery) =
   if selectQuery.Where <> Constant(Boolean true) then
-    failwith "WHERE in anonymizing queries is not currently supported"
+    failwith "WHERE in anonymizing queries is not currently supported."
 
 let private validateGeneralization accessLevel expression =
   if accessLevel <> Direct then


### PR DESCRIPTION
First, the global execution context is dropped and replaced with a global query context plus a per-subquery node anonymization context. Afterwards, the limited support for AID values floating is also dropped and data anonymization is moved to the leaf subquery nodes.

Closes #320.