### PR TITLE
When casting as boolean, produce Null on invalid value

### DIFF
--- a/src/OpenDiffix.Core.Tests/Expression.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Expression.Tests.fs
@@ -493,14 +493,19 @@ module DefaultFunctionsTests =
       [ //
         String "  1 ", String "integer", Integer 1L
         String "+0", String "integer", Integer 0L
+        String "+0.0", String "integer", Null
         String "-2", String "integer", Integer -2L
         String "0.5", String "real", Real 0.5
         String "-12.334", String "real", Real -12.334
+        String "-12.334.8", String "real", Null
         String "true", String "boolean", Boolean true
         String "TRUE", String "boolean", Boolean true
         String "1", String "boolean", Boolean true
         String "", String "boolean", Null
+        String "not a bool", String "boolean", Null
         String "False", String "boolean", Boolean false
+        String "  False", String "boolean", Boolean false
+        String "False  ", String "boolean", Boolean false
         Integer 100L, String "boolean", Boolean true
         Integer 0L, String "boolean", Boolean false
         Integer -1L, String "real", Real -1.

--- a/src/OpenDiffix.Core/Expression.fs
+++ b/src/OpenDiffix.Core/Expression.fs
@@ -190,13 +190,12 @@ let rec evaluateScalarFunction fn args =
     | true, r -> Real r
     | false, _ -> Null
   | Cast, [ String s; String "boolean" ] ->
-    match s.ToLower() with
+    match s.Trim().ToLower() with
     | "true"
     | "1" -> Boolean true
     | "false"
     | "0" -> Boolean false
-    | "" -> Null
-    | _ -> failwith "Input value is not a valid boolean string."
+    | _ -> Null
   | Cast, [ Integer i; String "real" ] -> i |> float |> Real
   | Cast, [ Real r; String "integer" ] -> r |> roundAwayFromZero |> int64 |> Integer
   | Cast, [ Integer 0L; String "boolean" ] -> Boolean false


### PR DESCRIPTION
Required for https://github.com/diffix/desktop/issues/282

I also decided to throw in a `Trim` in there. I noticed that PostgreSQL handles it like that.