### PR TITLE
Fix bug where count(value) in the query clashes with *-bucket hook

### DIFF
--- a/src/OpenDiffix.Core.Tests/StarBucket.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/StarBucket.Tests.fs
@@ -48,3 +48,20 @@ let ``Counts all suppressed buckets, but suppresses the star bucket`` () =
   |> ignore
 
   suppressedAnonCount |> should equal Null
+
+[<Fact>]
+let ``Works together with count(value) aggregators`` () =
+  let query =
+    """
+    SELECT letter, diffix_count(*, RowIndex), diffix_low_count(RowIndex), diffix_count(letter, RowIndex)
+    FROM table
+    GROUP BY 1
+    """
+
+  let mutable suppressedAnonCount = Null
+  let pullHookResultsCallback results = suppressedAnonCount <- results
+
+  HookTestHelpers.run [ StarBucket.hook pullHookResultsCallback ] csv query
+  |> ignore
+
+  suppressedAnonCount |> should equal (Integer 3L)


### PR DESCRIPTION
Without this fix, the finding function in `CommonTypes` would find both `DiffixCount` (i.e. `count(*), count(value)`) and on two finds, it would return a `None` resulting in an error `Cannot find required DiffixCount aggregator`.

This should fix it.

The `hasOnlyAidArgs` is very opportunistic and brittle, is there a better and still easy way?