### PR TITLE
Disallow ceil and ceil_by in untrusted access level

### DIFF
--- a/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
@@ -415,6 +415,10 @@ type Tests(db: DBFixture) =
       "Generalization used in the query is not allowed in untrusted access level."
 
     assertUntrustedQueryFails
+      "SELECT ceil_by(age, 2) from customers"
+      "Generalization used in the query is not allowed in untrusted access level."
+
+    assertUntrustedQueryFails
       "SELECT width_bucket(age, 2, 200, 5) from customers"
       "Generalization used in the query is not allowed in untrusted access level."
 
@@ -427,7 +431,6 @@ type Tests(db: DBFixture) =
     analyzeUntrustedQuery "SELECT floor_by(age, 0.2) from customers" |> ignore
     analyzeUntrustedQuery "SELECT floor_by(age, 20.0) from customers" |> ignore
     analyzeUntrustedQuery "SELECT floor_by(age, 50.0) from customers" |> ignore
-    analyzeUntrustedQuery "SELECT ceil_by(age, 50.0) from customers" |> ignore
     analyzeUntrustedQuery "SELECT round_by(age, 50.0) from customers" |> ignore
     // No generalization, either implicitly or explicitly
     analyzeUntrustedQuery "SELECT floor(age) from customers" |> ignore

--- a/src/OpenDiffix.Core/QueryValidator.fs
+++ b/src/OpenDiffix.Core/QueryValidator.fs
@@ -69,10 +69,7 @@ let private validateGeneralization accessLevel expression =
   if accessLevel = PublishUntrusted then
     match expression with
     | FunctionExpr (ScalarFunction fn, [ _ ]) when List.contains fn [ Floor; Ceil; Round ] -> ()
-    | FunctionExpr (ScalarFunction fn, [ _; arg ]) when
-      List.contains fn [ FloorBy; CeilBy; RoundBy ] && isMoneyStyle arg
-      ->
-      ()
+    | FunctionExpr (ScalarFunction fn, [ _; arg ]) when List.contains fn [ FloorBy; RoundBy ] && isMoneyStyle arg -> ()
     | FunctionExpr (ScalarFunction Substring, [ _; fromArg; _ ]) when fromArg = (1L |> Integer |> Constant) -> ()
     | ColumnReference _ -> ()
     | _ -> failwith "Generalization used in the query is not allowed in untrusted access level."


### PR DESCRIPTION
Closes #340 

(BTW, width_bucket has not been allowed in `publish_untrusted` already, in both implementations)