### PR TITLE
Use a more compatible version of *-bucket labels for seeding

### DIFF
--- a/src/OpenDiffix.Core/StarBucket.fs
+++ b/src/OpenDiffix.Core/StarBucket.fs
@@ -7,8 +7,11 @@ let private mergeAllAggregatorsInto (targetBucket: Bucket) (sourceBucket: Bucket
   sourceBucket.Aggregators |> Array.iteri (fun i -> targetAggregators.[i].Merge)
 
 let private makeStarBucket aggregationContext anonymizationContext =
-  // Group labels are all '*'s
-  let group = Array.create aggregationContext.GroupingLabels.Length (String "*")
+  // Group labels: '*'s for text and NULL for other, so that this can potentially be delivered
+  // as a properly typed row in a SQL query result.
+  let group =
+    aggregationContext.GroupingLabels
+    |> Array.map (fun expr -> if Expression.typeOf expr = StringType then String "*" else Null)
 
   let aggregators =
     aggregationContext.Aggregators


### PR DESCRIPTION
Related to https://github.com/diffix/pg_diffix/issues/345 & https://github.com/diffix/pg_diffix/pull/348

`pg_diffix` (or any other Diffix implementation, which will deliver the *-bucket using a pure SQL query-response interface), cannot use `*` for the *-bucket label, for non-string columns.

I propose to go down the same path as `pg_diffix` does, and (at current state of things, just for the sake of seed calculation), use `NULL` for non-string columns.