### PR TITLE
Generalize star-bucket callback.

### DIFF
--- a/src/OpenDiffix.Core.Tests/Led.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Led.Tests.fs
@@ -106,7 +106,10 @@ let ``Does not merge if the victim cannot be singled out`` () =
 let ``Merges taking precedence before star bucket hook`` () =
   // We get a hold of the star bucket results reference via side effects.
   let mutable suppressedAnonCount = Null
-  let pullHookResultsCallback results = suppressedAnonCount <- results
+
+  let pullHookResultsCallback aggCtx bucket =
+    suppressedAnonCount <- Bucket.getAggregate 0 aggCtx bucket
+
   let starBucketHook = StarBucket.hook pullHookResultsCallback
 
   let rows (result: QueryEngine.QueryResult) = result.Rows

--- a/src/OpenDiffix.Core.Tests/Led.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Led.Tests.fs
@@ -108,7 +108,7 @@ let ``Merges taking precedence before star bucket hook`` () =
   let mutable suppressedAnonCount = Null
 
   let pullHookResultsCallback aggCtx bucket =
-    suppressedAnonCount <- Bucket.getAggregate 0 aggCtx bucket
+    suppressedAnonCount <- Bucket.finalizeAggregate 0 aggCtx bucket
 
   let starBucketHook = StarBucket.hook pullHookResultsCallback
 

--- a/src/OpenDiffix.Core.Tests/StarBucket.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/StarBucket.Tests.fs
@@ -34,7 +34,7 @@ let ``Counts all suppressed buckets`` () =
   let mutable suppressedAnonCount = Null
 
   let pullHookResultsCallback aggCtx bucket =
-    suppressedAnonCount <- Bucket.getAggregate 0 aggCtx bucket
+    suppressedAnonCount <- Bucket.finalizeAggregate 0 aggCtx bucket
 
   HookTestHelpers.run [ StarBucket.hook pullHookResultsCallback ] csv query
   |> ignore
@@ -46,7 +46,7 @@ let ``Counts all suppressed buckets, but suppresses the star bucket`` () =
   let mutable suppressedAnonCount = Null
 
   let pullHookResultsCallback aggCtx bucket =
-    suppressedAnonCount <- Bucket.getAggregate 0 aggCtx bucket
+    suppressedAnonCount <- Bucket.finalizeAggregate 0 aggCtx bucket
 
   HookTestHelpers.run [ StarBucket.hook pullHookResultsCallback ] csvSuppressedStarBucket query
   |> ignore

--- a/src/OpenDiffix.Core/Bucket.fs
+++ b/src/OpenDiffix.Core/Bucket.fs
@@ -22,3 +22,6 @@ let putAttribute attr value bucket = bucket.Attributes.[attr] <- value
 let isLowCount lowCountIndex bucket aggregationContext =
   bucket.Aggregators.[lowCountIndex].Final(aggregationContext, bucket.AnonymizationContext)
   |> Value.unwrapBoolean
+
+let finalizeAggregate index aggregationContext bucket =
+  bucket.Aggregators.[index].Final(aggregationContext, bucket.AnonymizationContext)

--- a/src/OpenDiffix.Core/CommonTypes.fs
+++ b/src/OpenDiffix.Core/CommonTypes.fs
@@ -528,5 +528,5 @@ module AggregationContext =
     | None -> failwith "Cannot find required DiffixLowCount aggregator"
 
 module Bucket =
-  let getAggregate index aggregationContext bucket =
+  let finalizeAggregate index aggregationContext bucket =
     bucket.Aggregators.[index].Final(aggregationContext, bucket.AnonymizationContext)

--- a/src/OpenDiffix.Core/CommonTypes.fs
+++ b/src/OpenDiffix.Core/CommonTypes.fs
@@ -514,11 +514,6 @@ module Plan =
   let explain (plan: Plan) = toString 0 plan
 
 module AggregationContext =
-  let private hasOnlyAidArgs args =
-    match args with
-    | [ ListExpr _ ] -> true
-    | _ -> false
-
   let private findSingleIndex cond arr =
     arr
     |> Array.indexed
@@ -532,10 +527,6 @@ module AggregationContext =
     | Some index -> index
     | None -> failwith "Cannot find required DiffixLowCount aggregator"
 
-  let diffixCountIndex (aggregationContext: AggregationContext) =
-    match findSingleIndex
-      // We're looking for `count(*)`;`hasOnlyAidArgs` ensures we don't find a `count(value)`.
-      (fun ((fn, _), args) -> fn = DiffixCount && hasOnlyAidArgs args)
-      aggregationContext.Aggregators with
-    | Some index -> index
-    | None -> failwith "Cannot find required DiffixCount aggregator"
+module Bucket =
+  let getAggregate index aggregationContext bucket =
+    bucket.Aggregators.[index].Final(aggregationContext, bucket.AnonymizationContext)

--- a/src/OpenDiffix.Core/CommonTypes.fs
+++ b/src/OpenDiffix.Core/CommonTypes.fs
@@ -526,7 +526,3 @@ module AggregationContext =
     match findSingleIndex (fun ((fn, _), _) -> fn = DiffixLowCount) aggregationContext.Aggregators with
     | Some index -> index
     | None -> failwith "Cannot find required DiffixLowCount aggregator"
-
-module Bucket =
-  let finalizeAggregate index aggregationContext bucket =
-    bucket.Aggregators.[index].Final(aggregationContext, bucket.AnonymizationContext)

--- a/src/OpenDiffix.Core/StarBucket.fs
+++ b/src/OpenDiffix.Core/StarBucket.fs
@@ -48,7 +48,7 @@ let hook
 
   let isStarBucketLowCount =
     starBucket
-    |> Bucket.getAggregate lowCountIndex aggregationContext
+    |> Bucket.finalizeAggregate lowCountIndex aggregationContext
     |> Value.unwrapBoolean
 
   // NOTE: we can have a star bucket consisting of a single suppressed bucket,


### PR DESCRIPTION
The callback is now called only when the star-bucket exists and receives the entire bucket. This is needed to support Diffix for Desktop, where we are sometimes interested in `count(*)` and other times in `count(distinct AID)`.