### PR TITLE
Add DiffixSum

### DIFF
--- a/src/OpenDiffix.Core.Tests/Aggregator.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Aggregator.Tests.fs
@@ -12,13 +12,17 @@ let randomNullableInteger (random: System.Random) =
   // 10% chance to get a NULL
   if random.Next(10) = 0 then Null else Integer(random.Next(100) |> int64)
 
+let randomNullableReal (random: System.Random) =
+  // 10% chance to get a NULL
+  if random.Next(10) = 0 then Null else Real(random.Next(100) |> float)
+
 let buildAidInstancesSequence numAids (random: System.Random) =
   // Infinite sequence of (Value.List [aid1, aid2, ...])
   Seq.initInfinite (fun _ -> List.init numAids (fun _ -> randomNullableInteger random) |> Value.List)
 
-let buildIntegerSequence (random: System.Random) =
+let buildRealSequence (random: System.Random) =
   // Infinite sequence of (Value.Integer int | Null)
-  Seq.initInfinite (fun _ -> randomNullableInteger random)
+  Seq.initInfinite (fun _ -> randomNullableReal random)
 
 /// Builds a list of given length with aggregator transitions.
 /// Each transition contains AID instances as the first argument
@@ -26,7 +30,7 @@ let buildIntegerSequence (random: System.Random) =
 let makeAnonArgs hasValueArg random numAids length =
   (if hasValueArg then
      // Generates a sequence of [ Value.List [aid1, aid2, ...]; Value.Integer int ]
-     (buildAidInstancesSequence numAids random, buildIntegerSequence random)
+     (buildAidInstancesSequence numAids random, buildRealSequence random)
      ||> Seq.map2 (fun aidInstances argValue -> [ aidInstances; argValue ])
    else
      // Generates a sequence of [ Value.List [aid1, aid2, ...] ]
@@ -39,7 +43,7 @@ let makeAnonArgs hasValueArg random numAids length =
 let makeStandardArgs hasValueArg random length =
   (if hasValueArg then
      // Generates a sequence of [ Value.Integer int ]
-     buildIntegerSequence random |> Seq.map (fun argValue -> [ argValue ])
+     buildRealSequence random |> Seq.map (fun argValue -> [ argValue ])
    else
      // Generates a sequence of [ ]
      Seq.initInfinite (fun _ -> []))
@@ -130,6 +134,10 @@ let testStandard distinct hasArg fn =
 let ``Merging DiffixCount`` () =
   DiffixCount |> testAnon NON_DISTINCT WITH_VALUE_ARG
   DiffixCount |> testAnon NON_DISTINCT WITHOUT_VALUE_ARG
+
+[<Fact>]
+let ``Merging DiffixSum`` () =
+  DiffixSum |> testAnon NON_DISTINCT WITH_VALUE_ARG
 
 [<Fact>]
 let ``Merging distinct DiffixCount`` () =

--- a/src/OpenDiffix.Core.Tests/Aggregator.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Aggregator.Tests.fs
@@ -26,7 +26,7 @@ let buildRealSequence (random: System.Random) =
 
 /// Builds a list of given length with aggregator transitions.
 /// Each transition contains AID instances as the first argument
-/// and an optional random integer as the second argument.
+/// and an optional random integer (as `Real`) as the second argument.
 let makeAnonArgs hasValueArg random numAids length =
   (if hasValueArg then
      // Generates a sequence of [ Value.List [aid1, aid2, ...]; Value.Integer int ]
@@ -53,16 +53,18 @@ let makeStandardArgs hasValueArg random length =
 /// Verifies that merging 2 separately aggregated sequences is equivalent
 /// to a single aggregation of those 2 sequences concatenated.
 let ensureConsistentMerging ctx fn sourceArgs destinationArgs =
-  let sourceAggregator = Aggregator.create fn
+  let DUMMY_ARGS = [ ListExpr [ ColumnReference(0, IntegerType) ]; ColumnReference(1, RealType) ]
+
+  let sourceAggregator = Aggregator.create (fn, DUMMY_ARGS)
   sourceArgs |> List.iter sourceAggregator.Transition
 
-  let destinationAggregator = Aggregator.create fn
+  let destinationAggregator = Aggregator.create (fn, DUMMY_ARGS)
   destinationArgs |> List.iter destinationAggregator.Transition
 
   destinationAggregator.Merge sourceAggregator
   let mergedFinal = destinationAggregator.Final ctx
 
-  let replayedAggregator = Aggregator.create fn
+  let replayedAggregator = Aggregator.create (fn, DUMMY_ARGS)
   (destinationArgs @ sourceArgs) |> List.iter replayedAggregator.Transition
   let replayedFinal = replayedAggregator.Final ctx
 

--- a/src/OpenDiffix.Core.Tests/Anonymizer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Anonymizer.Tests.fs
@@ -7,22 +7,27 @@ open CommonTypes
 
 let companies i =
   let names = [ "Alpha"; "Beta"; "Gamma"; "Delta" ]
-  names |> List.item (i % names.Length)
+  names |> List.item (i % names.Length) |> String
+
+let reals i =
+  let reals = [ 0.1; 0.0; 1.0; -0.01 ]
+  reals |> List.item (i % reals.Length) |> Real
 
 let rows =
   [ 1, 5; 2, 4; 3, 2; 4, 1; 5, 5; 6, 4; 7, 3; 8, 6 ]
   |> List.collect (fun (id, count) -> List.replicate count id)
-  |> List.map (fun id -> [| id |> int64 |> Integer; String "value"; companies id |> String |])
+  |> List.map (fun id -> [| id |> int64 |> Integer; String "value"; companies id; reals id |])
   |> List.append [
-       [| Null; String "value"; String "Alpha" |]
-       [| Integer 8L; Null; String "Alpha" |]
-       [| Integer 9L; String "value"; Null |]
+       [| Null; String "value"; String "Alpha"; Real -100.0 |]
+       [| Integer 8L; Null; String "Alpha"; Null |]
+       [| Integer 9L; String "value"; Null; Real 10.0 |]
      ]
 
 let aidColumn = ColumnReference(0, IntegerType)
 let aidColumnList = ListExpr [ aidColumn ]
 let strColumn = ColumnReference(1, StringType)
 let companyColumn = ColumnReference(2, StringType)
+let realColumn = ColumnReference(3, RealType)
 let allAidColumns = ListExpr [ aidColumn; companyColumn ]
 
 let anonParams =
@@ -45,6 +50,7 @@ let evaluateAggregator fn args =
 let distinctDiffixCount = DiffixCount, { AggregateOptions.Default with Distinct = true }
 let diffixCount = DiffixCount, { AggregateOptions.Default with Distinct = false }
 let diffixLowCount = DiffixLowCount, AggregateOptions.Default
+let diffixSum = DiffixSum, { AggregateOptions.Default with Distinct = false }
 
 [<Fact>]
 let ``anon count distinct column`` () =
@@ -78,6 +84,25 @@ let ``anon count(col)`` () =
   |> should equal (Integer 30L)
 
 [<Fact>]
+let ``anon sum(real col)`` () =
+  // - 1 user with Null real is ignored
+  // - replacing positive outlier 10.0 with 4.0
+  // - replacing negative outlier 3x -0.01 with 2x -0.01
+  // - end up with 4.0 + 4.0 + 4.0 + 0.7 - 0.02 - 0.02
+  rows
+  |> evaluateAggregator diffixSum [ aidColumnList; realColumn ]
+  |> function
+    | Real value -> value
+    | _ -> failwith "Unexpected aggregator result"
+  |> should (equalWithin 1e-10) 12.66
+
+[<Fact>]
+let ``anon sum(int col)`` () =
+  rows
+  |> evaluateAggregator diffixSum [ aidColumnList; aidColumn ]
+  |> should equal (Integer 127L)
+
+[<Fact>]
 let ``anon count returns 0 if insufficient users`` () =
   let firstRow = rows |> List.take 1
 
@@ -98,12 +123,50 @@ let ``anon count returns 0 for Null inputs`` () =
   |> should equal (Integer 0L)
 
 [<Fact>]
+let ``anon sum returns Null for Null inputs`` () =
+  let rows = [ 1L .. 10L ] |> List.map (fun i -> [| Integer i; Null; Null; Null |])
+
+  rows
+  |> evaluateAggregator diffixSum [ aidColumnList; realColumn ]
+  |> should equal Null
+
+[<Fact>]
 let ``anon count returns 0 when all AIDs null`` () =
   let rows = [ 1L .. 10L ] |> List.map (fun _ -> [| Null; String "value"; Null |])
 
   rows
   |> evaluateAggregator diffixCount [ allAidColumns; strColumn ]
   |> should equal (Integer 0L)
+
+[<Fact>]
+let ``anon sum returns null when all AIDs null`` () =
+  let rows = [ 1L .. 10L ] |> List.map (fun _ -> [| Null; Null; Null; Real 10.0 |])
+
+  rows
+  |> evaluateAggregator diffixSum [ aidColumnList; realColumn ]
+  |> should equal Null
+
+[<Fact>]
+let ``anon sum accepts 0.0 as contributions for both positive and negative`` () =
+  let rows =
+    [ 1L .. 10L ]
+    |> List.map (fun i -> [| Integer i; Null; Null; Real 0.0 |])
+    |> List.append ([ [| Integer 11L; Null; Null; Real -10.0 |]; [| Integer 12L; Null; Null; Real 10.0 |] ])
+
+  rows
+  |> evaluateAggregator diffixSum [ aidColumnList; realColumn ]
+  |> should equal (Real 0.0)
+
+[<Fact>]
+let ``anon sum ignores nulls completely, flattening included`` () =
+  let rows =
+    [ 1L .. 10L ]
+    |> List.map (fun i -> [| Integer i; Null; Null; Null |])
+    |> List.append ([ [| Integer 11L; Null; Null; Real -10.0 |]; [| Integer 12L; Null; Null; Real 10.0 |] ])
+
+  rows
+  |> evaluateAggregator diffixSum [ aidColumnList; realColumn ]
+  |> should equal Null
 
 [<Fact>]
 let ``multi-AID count`` () =

--- a/src/OpenDiffix.Core.Tests/Anonymizer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Anonymizer.Tests.fs
@@ -68,27 +68,27 @@ let ``anon count distinct column`` () =
 
 [<Fact>]
 let ``anon count()`` () =
-  // - replacing outlier 6, with top 5 --> flattened by 1
-  // - noise proportional to top group average of 5
+  // replacing outlier 6, with top 5 --> flattened by 1
+  // noise proportional to top group average of 5
   rows
   |> evaluateAggregator diffixCount [ aidColumnList ]
   |> should equal (Integer 30L)
 
 [<Fact>]
 let ``anon count(col)`` () =
-  // - 1 user with Null string is ignored
-  // - replacing outlier 6 with top 5
-  // - noise proportional to top group average of 5
+  // 1 user with Null string is ignored
+  // replacing outlier 6 with top 5
+  // noise proportional to top group average of 5
   rows
   |> evaluateAggregator diffixCount [ aidColumnList; strColumn ]
   |> should equal (Integer 30L)
 
 [<Fact>]
 let ``anon sum(real col)`` () =
-  // - 1 user with Null real is ignored
-  // - replacing positive outlier 10.0 with 4.0
-  // - replacing negative outlier 3x -0.01 with 2x -0.01
-  // - end up with 4.0 + 4.0 + 4.0 + 0.7 - 0.02 - 0.02
+  // 1 user with Null real is ignored
+  // replacing positive outlier 10.0 with 4.0
+  // replacing negative outlier 3x -0.01 with 2x -0.01
+  // end up with 4.0 + 4.0 + 4.0 + 0.7 - 0.02 - 0.02
   rows
   |> evaluateAggregator diffixSum [ aidColumnList; realColumn ]
   |> function

--- a/src/OpenDiffix.Core.Tests/QueryEngine.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/QueryEngine.Tests.fs
@@ -70,11 +70,16 @@ type Tests(db: DBFixture) =
   let ``query 4`` () =
     let expected =
       {
-        Columns = [ { Name = "city"; Type = StringType }; { Name = "count"; Type = IntegerType } ]
-        Rows = [ [| String "Berlin"; Integer 10L |]; [| String "Rome"; Integer 10L |] ]
+        Columns =
+          [
+            { Name = "city"; Type = StringType }
+            { Name = "count"; Type = IntegerType }
+            { Name = "sum"; Type = RealType }
+          ]
+        Rows = [ [| String "Berlin"; Integer 10L; Integer 320L |]; [| String "Rome"; Integer 10L; Integer 300L |] ]
       }
 
-    let queryResult = runQuery "SELECT city, count(distinct id) FROM customers_small GROUP BY city"
+    let queryResult = runQuery "SELECT city, count(distinct id), sum(age) FROM customers_small GROUP BY city"
     queryResult |> should equal expected
 
   [<Fact>]

--- a/src/OpenDiffix.Core.Tests/TestHelpers.fs
+++ b/src/OpenDiffix.Core.Tests/TestHelpers.fs
@@ -6,7 +6,7 @@ type DBFixture() =
     new OpenDiffix.CLI.SQLite.DataProvider(__SOURCE_DIRECTORY__ + "/../../data/data.sqlite") :> IDataProvider
 
 let evaluateAggregator ctx aggSpec args rows =
-  let aggregator = Aggregator.create aggSpec
+  let aggregator = Aggregator.create (aggSpec, args)
   let processor = fun row -> args |> List.map (Expression.evaluate row) |> aggregator.Transition
   List.iter processor rows
   aggregator.Final ctx

--- a/src/OpenDiffix.Core/Aggregator.fs
+++ b/src/OpenDiffix.Core/Aggregator.fs
@@ -184,8 +184,8 @@ type private DiffixCount() =
         Integer minCount
       else
         match Anonymizer.count aggContext.AnonymizationParams anonContext state with
-        | Anonymizer.CountResult.NotEnoughAIDVs -> Integer minCount
-        | Anonymizer.CountResult.Ok value -> Integer(max value minCount)
+        | Anonymizer.AnonymizedResult.NotEnoughAIDVs -> Integer minCount
+        | Anonymizer.AnonymizedResult.Ok value -> Integer(max value minCount)
 
 type private DiffixCountDistinct() =
   let mutable aidsCount = Option<int>.None
@@ -245,8 +245,8 @@ type private DiffixCountDistinct() =
         Integer minCount
       else
         match Anonymizer.countDistinct aggContext.AnonymizationParams anonContext aidsCount.Value aidsPerValue with
-        | Anonymizer.CountResult.NotEnoughAIDVs -> Integer minCount
-        | Anonymizer.CountResult.Ok value -> Integer(max value minCount)
+        | Anonymizer.AnonymizedResult.NotEnoughAIDVs -> Integer minCount
+        | Anonymizer.AnonymizedResult.Ok value -> Integer(max value minCount)
 
 type private DiffixLowCount() =
   let mutable state: HashSet<AidHash> [] = null
@@ -394,8 +394,8 @@ type private DiffixSum() =
         Null
       else
         match Anonymizer.sum aggContext.AnonymizationParams anonContext state with
-        | Anonymizer.CountResult.NotEnoughAIDVs -> Null
-        | Anonymizer.CountResult.Ok value -> value
+        | Anonymizer.AnonymizedResult.NotEnoughAIDVs -> Null
+        | Anonymizer.AnonymizedResult.Ok value -> value
 
 // ----------------------------------------------------------------
 // Public API

--- a/src/OpenDiffix.Core/Aggregator.fs
+++ b/src/OpenDiffix.Core/Aggregator.fs
@@ -39,6 +39,17 @@ let private unwrapAnonContext anonymizationContext =
   | Some anonymizationContext -> anonymizationContext
   | None -> failwith "Anonymizing aggregator called with empty anonymization context."
 
+/// Increases contribution of a single AID value.
+let private increaseContribution valueIncrease aidValue (aidMap: Dictionary<AidHash, float>) =
+  let aidHash = hashAid aidValue
+
+  let updatedContribution =
+    match aidMap.TryGetValue(aidHash) with
+    | true, aidContribution -> aidContribution + valueIncrease
+    | false, _ -> valueIncrease
+
+  aidMap.[aidHash] <- updatedContribution
+
 // ----------------------------------------------------------------
 // Aggregators
 // ----------------------------------------------------------------
@@ -100,18 +111,7 @@ type private DiffixCount() =
   let mutable state: Anonymizer.AidCountState array = null
 
   let initialState length : Anonymizer.AidCountState array =
-    Array.init length (fun _ -> { AidContributions = Dictionary<AidHash, float>(); UnaccountedFor = 0L })
-
-  /// Increases contribution of a single AID value.
-  let increaseContribution valueIncrease aidValue (aidMap: Dictionary<AidHash, float>) =
-    let aidHash = hashAid aidValue
-
-    let updatedContribution =
-      match aidMap.TryGetValue(aidHash) with
-      | true, aidContribution -> aidContribution + valueIncrease
-      | false, _ -> valueIncrease
-
-    aidMap.[aidHash] <- updatedContribution
+    Array.init length (fun _ -> { AidContributions = Dictionary<AidHash, float>(); UnaccountedFor = 0.0 })
 
   /// Increases contribution of all AID instances.
   let increaseContributions valueIncrease (aidInstances: Value list) =
@@ -148,9 +148,9 @@ type private DiffixCount() =
     member this.Transition args =
       match args with
       | Value.List [] :: _ -> invalidArgs args
-      | [ aidInstances; Null ] -> updateAidMaps aidInstances 0L
+      | [ aidInstances; Null ] -> updateAidMaps aidInstances 0.0
       | [ aidInstances ]
-      | [ aidInstances; _ ] -> updateAidMaps aidInstances 1L
+      | [ aidInstances; _ ] -> updateAidMaps aidInstances 1.0
       | _ -> invalidArgs args
 
     member this.Merge aggregator =
@@ -288,6 +288,115 @@ type private DiffixLowCount() =
       else
         Boolean(Anonymizer.isLowCount aggContext.AnonymizationParams anonContext state)
 
+type private DiffixSum() =
+  let nullState: Anonymizer.SumState = { Positive = null; Negative = null; IsReal = false }
+  let mutable state = nullState
+
+  let initialState length : Anonymizer.SumState =
+    { nullState with
+        Positive =
+          Array.init length (fun _ -> { AidContributions = Dictionary<AidHash, float>(); UnaccountedFor = 0.0 })
+        Negative =
+          Array.init length (fun _ -> { AidContributions = Dictionary<AidHash, float>(); UnaccountedFor = 0.0 })
+    }
+
+  let increaseUnaccountedFor valueIncrease i =
+    let absValueIncrease = abs (valueIncrease)
+
+    if valueIncrease > 0.0 then
+      state.Positive.[i].UnaccountedFor <- state.Positive.[i].UnaccountedFor + absValueIncrease
+    else if valueIncrease < 0.0 then
+      state.Negative.[i].UnaccountedFor <- state.Negative.[i].UnaccountedFor + absValueIncrease
+    else
+      state.Positive.[i].UnaccountedFor <- state.Positive.[i].UnaccountedFor + absValueIncrease
+      state.Negative.[i].UnaccountedFor <- state.Negative.[i].UnaccountedFor + absValueIncrease
+
+  let increaseSumContribution valueIncrease aidValue i =
+    let absValueIncrease = abs (valueIncrease)
+
+    if valueIncrease > 0.0 then
+      increaseContribution absValueIncrease aidValue state.Positive.[i].AidContributions
+    else if valueIncrease < 0.0 then
+      increaseContribution absValueIncrease aidValue state.Negative.[i].AidContributions
+    else
+      increaseContribution absValueIncrease aidValue state.Positive.[i].AidContributions
+      increaseContribution absValueIncrease aidValue state.Negative.[i].AidContributions
+
+
+  /// Increases contribution of all AID instances.
+  let increaseContributions valueIncrease (aidInstances: Value list) =
+    aidInstances
+    |> List.iteri (fun i aidValue ->
+      match aidValue with
+      // No AIDs, add to unaccounted value
+      | Null
+      | Value.List [] -> increaseUnaccountedFor valueIncrease i
+      // List of AIDs, distribute contribution evenly
+      | Value.List aidValues ->
+        let partialIncrease = valueIncrease / (aidValues |> List.length |> float)
+
+        aidValues
+        |> List.iter (fun aidValue -> increaseSumContribution partialIncrease aidValue i)
+      // Single AID, add to its contribution
+      | aidValue -> increaseSumContribution valueIncrease aidValue i
+    )
+
+  let updateAidMaps aidInstances valueIncrease =
+    match aidInstances with
+    | Value.List aidInstances ->
+      if state = nullState then state <- initialState aidInstances.Length
+
+      if not <| List.forall missingAid aidInstances then
+        increaseContributions valueIncrease aidInstances
+    | _ -> failwith "Expecting a list as input"
+
+  member this.State = state
+
+  interface IAggregator with
+    member this.Transition args =
+      match args with
+      | Value.List [] :: _ -> invalidArgs args
+      // Note that we're completely ignoring `Null`, contrary to `count(col)` where it contributed 0.
+      | [ aidInstances; Null ] -> ()
+      | [ aidInstances; Integer value ] -> updateAidMaps aidInstances (float value)
+      | [ aidInstances; Real value ] ->
+        updateAidMaps aidInstances value
+        state.IsReal <- true
+      | _ -> invalidArgs args
+
+    member this.Merge aggregator =
+      let otherState = (castAggregator<DiffixSum> aggregator).State
+
+      if otherState <> nullState then
+        if state = nullState then state <- initialState otherState.Positive.Length
+
+        let mergeStateLeg (leg: Anonymizer.AidCountState array) (otherLeg: Anonymizer.AidCountState array) =
+          otherLeg
+          |> Array.iteri (fun i otherAidCountState ->
+            let aidCountState = leg.[i]
+            let aidContributions = aidCountState.AidContributions
+            aidCountState.UnaccountedFor <- aidCountState.UnaccountedFor + otherAidCountState.UnaccountedFor
+
+            otherAidCountState.AidContributions
+            |> Seq.iter (fun pair ->
+              aidContributions.[pair.Key] <- (aidContributions |> Dictionary.getOrDefault pair.Key 0.0) + pair.Value
+            )
+          )
+
+        mergeStateLeg state.Positive otherState.Positive
+        mergeStateLeg state.Negative otherState.Negative
+        state.IsReal <- state.IsReal || otherState.IsReal
+
+    member this.Final(aggContext, anonContext) =
+      let anonContext = unwrapAnonContext anonContext
+
+      if state = nullState then
+        Null
+      else
+        match Anonymizer.sum aggContext.AnonymizationParams anonContext state with
+        | Anonymizer.CountResult.NotEnoughAIDVs -> Null
+        | Anonymizer.CountResult.Ok value -> value
+
 // ----------------------------------------------------------------
 // Public API
 // ----------------------------------------------------------------
@@ -297,7 +406,8 @@ type T = IAggregator
 let isAnonymizing ((fn, _args): AggregatorSpec) =
   match fn with
   | DiffixCount
-  | DiffixLowCount -> true
+  | DiffixLowCount
+  | DiffixSum -> true
   | _ -> false
 
 let create (aggSpec: AggregatorSpec) : T =
@@ -308,4 +418,5 @@ let create (aggSpec: AggregatorSpec) : T =
   | DiffixCount, { Distinct = false } -> DiffixCount() :> T
   | DiffixCount, { Distinct = true } -> DiffixCountDistinct() :> T
   | DiffixLowCount, _ -> DiffixLowCount() :> T
+  | DiffixSum, { Distinct = false } -> DiffixSum() :> T
   | _ -> failwith "Invalid aggregator"

--- a/src/OpenDiffix.Core/Aggregator.fs
+++ b/src/OpenDiffix.Core/Aggregator.fs
@@ -303,23 +303,19 @@ type private DiffixSum() =
   let increaseUnaccountedFor valueIncrease i =
     let absValueIncrease = abs (valueIncrease)
 
-    if valueIncrease > 0.0 then
+    if valueIncrease >= 0.0 then
       state.Positive.[i].UnaccountedFor <- state.Positive.[i].UnaccountedFor + absValueIncrease
-    else if valueIncrease < 0.0 then
-      state.Negative.[i].UnaccountedFor <- state.Negative.[i].UnaccountedFor + absValueIncrease
-    else
-      state.Positive.[i].UnaccountedFor <- state.Positive.[i].UnaccountedFor + absValueIncrease
+
+    if valueIncrease <= 0.0 then
       state.Negative.[i].UnaccountedFor <- state.Negative.[i].UnaccountedFor + absValueIncrease
 
   let increaseSumContribution valueIncrease aidValue i =
     let absValueIncrease = abs (valueIncrease)
 
-    if valueIncrease > 0.0 then
+    if valueIncrease >= 0.0 then
       increaseContribution absValueIncrease aidValue state.Positive.[i].AidContributions
-    else if valueIncrease < 0.0 then
-      increaseContribution absValueIncrease aidValue state.Negative.[i].AidContributions
-    else
-      increaseContribution absValueIncrease aidValue state.Positive.[i].AidContributions
+
+    if valueIncrease <= 0.0 then
       increaseContribution absValueIncrease aidValue state.Negative.[i].AidContributions
 
 
@@ -356,8 +352,8 @@ type private DiffixSum() =
     member this.Transition args =
       match args with
       | Value.List [] :: _ -> invalidArgs args
-      // Note that we're completely ignoring `Null`, contrary to `count(col)` where it contributed 0.
-      | [ aidInstances; Null ] -> ()
+      // Note that we're completely ignoring `Null`, contrary to `count(col)` where it contributes 0.
+      | [ _; Null ] -> ()
       | [ aidInstances; Integer value ] -> updateAidMaps aidInstances (float value)
       | [ aidInstances; Real value ] ->
         updateAidMaps aidInstances value

--- a/src/OpenDiffix.Core/Analyzer.fs
+++ b/src/OpenDiffix.Core/Analyzer.fs
@@ -55,6 +55,15 @@ let private mapFunctionExpression rangeColumns fn parsedArgs =
 
      let aids = parsedAids |> List.map (mapExpression rangeColumns) |> ListExpr
      AggregateFunction(DiffixCount, aggregateArgs), aids :: args
+   | AggregateFunction (DiffixSum, aggregateArgs), parsedArg :: parsedAids ->
+     let aggregateArgs, args =
+       match parsedArg with
+       | ParserTypes.Distinct parsedExpr ->
+         { aggregateArgs with Distinct = true }, [ mapExpression rangeColumns parsedExpr ]
+       | parsedExpr -> aggregateArgs, [ mapExpression rangeColumns parsedExpr ]
+
+     let aids = parsedAids |> List.map (mapExpression rangeColumns) |> ListExpr
+     AggregateFunction(DiffixSum, aggregateArgs), aids :: args
    | AggregateFunction (aggregate, aggregateArgs), [ ParserTypes.Distinct expr ] ->
      let arg = mapExpression rangeColumns expr
      AggregateFunction(aggregate, { aggregateArgs with Distinct = true }), [ arg ]

--- a/src/OpenDiffix.Core/Anonymizer.fs
+++ b/src/OpenDiffix.Core/Anonymizer.fs
@@ -3,6 +3,20 @@ module OpenDiffix.Core.Anonymizer
 open System
 open System.Security.Cryptography
 
+[<RequireQualifiedAccess>]
+type AnonymizedResult<'okType> =
+  | NotEnoughAIDVs
+  | Ok of 'okType
+
+type AidCountState = { AidContributions: Dictionary<AidHash, float>; mutable UnaccountedFor: float }
+
+type SumState =
+  {
+    Positive: AidCountState array
+    Negative: AidCountState array
+    mutable IsReal: bool
+  }
+
 // ----------------------------------------------------------------
 // Random & noise
 // ----------------------------------------------------------------
@@ -148,6 +162,17 @@ let inline private aidFlattening
         Noise = noise
       }
 
+let private arrayFromDict (d: Dictionary<'a, 'b>) =
+  d |> Seq.map (fun pair -> pair.Key, pair.Value) |> Seq.toArray
+
+let private mapAidFlattening (anonParams: AnonymizationParams) (anonContext: AnonymizationContext) perAidContributions =
+  perAidContributions
+  |> Array.map (fun aidState ->
+    aidState.AidContributions
+    |> arrayFromDict
+    |> aidFlattening anonParams anonContext aidState.UnaccountedFor
+  )
+
 let private sortByValue (aidsPerValue: KeyValuePair<Value, HashSet<AidHash> array> seq) =
   let comparer = Value.comparer Ascending NullsFirst
   aidsPerValue |> (Seq.sortWith (fun kvA kvB -> comparer kvA.Key kvB.Key))
@@ -258,11 +283,6 @@ let isLowCount (anonParams: AnonymizationParams) (anonContext: AnonymizationCont
   )
   |> Seq.reduce (||)
 
-[<RequireQualifiedAccess>]
-type CountResult<'okType> =
-  | NotEnoughAIDVs
-  | Ok of 'okType
-
 let countDistinct
   (anonParams: AnonymizationParams)
   (anonContext: AnonymizationContext)
@@ -291,88 +311,55 @@ let countDistinct
   // we can only report the count of values we already know to be safe as they
   // individually passed low count filtering.
   if byAid |> List.exists ((=) None) then
-    if safeCount > 0L then CountResult.Ok safeCount else CountResult.NotEnoughAIDVs
+    if safeCount > 0L then
+      AnonymizedResult.Ok safeCount
+    else
+      AnonymizedResult.NotEnoughAIDVs
   else
     byAid
     |> List.choose id
     |> anonymizedSum
-    |> (Math.roundAwayFromZero >> int64 >> (+) safeCount >> CountResult.Ok)
-
-type AidCountState = { AidContributions: Dictionary<AidHash, float>; mutable UnaccountedFor: float }
-
-type SumState =
-  {
-    Positive: AidCountState array
-    Negative: AidCountState array
-    mutable IsReal: bool
-  }
-
-let private arrayFromDict (d: Dictionary<'a, 'b>) =
-  d |> Seq.map (fun pair -> pair.Key, pair.Value) |> Seq.toArray
+    |> (Math.roundAwayFromZero >> int64 >> (+) safeCount >> AnonymizedResult.Ok)
 
 let count
   (anonParams: AnonymizationParams)
   (anonContext: AnonymizationContext)
   (perAidContributions: AidCountState array)
   =
-  let byAid =
-    perAidContributions
-    |> Array.map (fun aidState ->
-      aidState.AidContributions
-      |> arrayFromDict
-      |> aidFlattening anonParams anonContext aidState.UnaccountedFor
-    )
+  let byAid = mapAidFlattening anonParams anonContext perAidContributions
 
   // If any of the AIDs had insufficient data to produce a sensible flattening
   // we have to abort anonymization.
   if byAid |> Array.exists ((=) None) then
-    CountResult.NotEnoughAIDVs
+    AnonymizedResult.NotEnoughAIDVs
   else
     byAid
     |> Array.choose id
     |> anonymizedSum
-    |> (Math.roundAwayFromZero >> int64 >> CountResult.Ok)
+    |> (Math.roundAwayFromZero >> int64 >> AnonymizedResult.Ok)
 
 let sum (anonParams: AnonymizationParams) (anonContext: AnonymizationContext) (perAidContributions: SumState) =
-  let byAidPositive =
-    perAidContributions.Positive
-    |> Array.map (fun aidState ->
-      aidState.AidContributions
-      |> arrayFromDict
-      |> aidFlattening anonParams anonContext aidState.UnaccountedFor
-    )
-
-  let byAidNegative =
-    perAidContributions.Negative
-    |> Array.map (fun aidState ->
-      aidState.AidContributions
-      |> arrayFromDict
-      |> aidFlattening anonParams anonContext aidState.UnaccountedFor
-    )
+  let byAidPositive = mapAidFlattening anonParams anonContext perAidContributions.Positive
+  let byAidNegative = mapAidFlattening anonParams anonContext perAidContributions.Negative
 
   // If any of the AIDs had insufficient data to produce a sensible flattening
   // for both positive and negative values, we have to abort anonymization.
   if (Array.zip byAidPositive byAidNegative) |> Array.exists ((=) (None, None)) then
-    CountResult.NotEnoughAIDVs
+    AnonymizedResult.NotEnoughAIDVs
   else
+    let anonymizedSumOnNonEmpty =
+      Array.choose id
+      >> function
+        | [||] -> 0.0
+        | nonEmpty -> anonymizedSum nonEmpty
+
     // Using `anonymizedSum` separately for positive and negative, we ensure that we pick the appropriate
     // amount of flattening and noise for each leg, and only later combine the results.
-    let positive =
-      byAidPositive
-      |> Array.choose id
-      |> function
-        | [||] -> 0.0
-        | nonEmpty -> anonymizedSum nonEmpty
-
-    let negative =
-      byAidNegative
-      |> Array.choose id
-      |> function
-        | [||] -> 0.0
-        | nonEmpty -> anonymizedSum nonEmpty
+    let positive = anonymizedSumOnNonEmpty byAidPositive
+    let negative = anonymizedSumOnNonEmpty byAidNegative
 
     if perAidContributions.IsReal then
-      (positive - negative) |> (Real >> CountResult.Ok)
+      (positive - negative) |> (Real >> AnonymizedResult.Ok)
     else
       (positive - negative)
-      |> (Math.roundAwayFromZero >> int64 >> Integer >> CountResult.Ok)
+      |> (Math.roundAwayFromZero >> int64 >> Integer >> AnonymizedResult.Ok)

--- a/src/OpenDiffix.Core/Anonymizer.fs
+++ b/src/OpenDiffix.Core/Anonymizer.fs
@@ -4,14 +4,15 @@ open System
 open System.Security.Cryptography
 
 [<RequireQualifiedAccess>]
-type AnonymizedResult<'okType> =
+type AnonymizedResult<'T> =
   | NotEnoughAIDVs
-  | Ok of 'okType
+  | Ok of 'T
 
 type AidCountState = { AidContributions: Dictionary<AidHash, float>; mutable UnaccountedFor: float }
 
 type SumState =
   {
+    // Both `Positive` and `Negative` include 0.0 contributions by design, but for simplicity we call it like this.
     Positive: AidCountState array
     Negative: AidCountState array
     mutable IsReal: bool

--- a/src/OpenDiffix.Core/Anonymizer.fs
+++ b/src/OpenDiffix.Core/Anonymizer.fs
@@ -15,7 +15,6 @@ type SumState =
     // Both `Positive` and `Negative` include 0.0 contributions by design, but for simplicity we call it like this.
     Positive: AidCountState array
     Negative: AidCountState array
-    mutable IsReal: bool
   }
 
 // ----------------------------------------------------------------
@@ -339,7 +338,7 @@ let count
     |> anonymizedSum
     |> (Math.roundAwayFromZero >> int64 >> AnonymizedResult.Ok)
 
-let sum (anonParams: AnonymizationParams) (anonContext: AnonymizationContext) (perAidContributions: SumState) =
+let sum (anonParams: AnonymizationParams) (anonContext: AnonymizationContext) (perAidContributions: SumState) isReal =
   let byAidPositive = mapAidFlattening anonParams anonContext perAidContributions.Positive
   let byAidNegative = mapAidFlattening anonParams anonContext perAidContributions.Negative
 
@@ -359,7 +358,7 @@ let sum (anonParams: AnonymizationParams) (anonContext: AnonymizationContext) (p
     let positive = anonymizedSumOnNonEmpty byAidPositive
     let negative = anonymizedSumOnNonEmpty byAidNegative
 
-    if perAidContributions.IsReal then
+    if isReal then
       (positive - negative) |> (Real >> AnonymizedResult.Ok)
     else
       (positive - negative)

--- a/src/OpenDiffix.Core/CommonTypes.fs
+++ b/src/OpenDiffix.Core/CommonTypes.fs
@@ -80,6 +80,7 @@ type AggregateFunction =
   | DiffixCount
   | DiffixLowCount
   | Sum
+  | DiffixSum
 
 type AggregateOptions =
   {
@@ -319,6 +320,7 @@ module Function =
     | "sum" -> AggregateFunction(Sum, AggregateOptions.Default)
     | "diffix_count" -> AggregateFunction(DiffixCount, AggregateOptions.Default)
     | "diffix_low_count" -> AggregateFunction(DiffixLowCount, AggregateOptions.Default)
+    | "diffix_sum" -> AggregateFunction(DiffixSum, AggregateOptions.Default)
     | "+" -> ScalarFunction Add
     | "-" -> ScalarFunction Subtract
     | "*" -> ScalarFunction Multiply

--- a/src/OpenDiffix.Core/Executor.fs
+++ b/src/OpenDiffix.Core/Executor.fs
@@ -60,10 +60,10 @@ let private invokeHooks aggregationContext anonymizationContext hooks buckets =
 let private executeAggregate queryContext (childPlan, groupingLabels, aggregators, anonymizationContext) : seq<Row> =
   let groupingLabels = Array.ofList groupingLabels
   let aggregators = Utils.unpackAggregators aggregators
-  let aggSpecs, aggArgs = Array.unzip aggregators
+  let _aggSpecs, aggArgs = Array.unzip aggregators
 
   let makeBucket group anonymizationContext =
-    Bucket.make group (aggSpecs |> Array.map Aggregator.create) anonymizationContext
+    Bucket.make group (aggregators |> Array.map Aggregator.create) anonymizationContext
 
   let state = Dictionary<Row, Bucket>(Row.equalityComparer)
 

--- a/src/OpenDiffix.Core/Expression.fs
+++ b/src/OpenDiffix.Core/Expression.fs
@@ -67,6 +67,7 @@ let typeOfAggregate fn args =
   | DiffixCount -> IntegerType
   | DiffixLowCount -> BooleanType
   | Sum -> RealType
+  | DiffixSum -> RealType
 
 /// Resolves the type of an expression.
 let rec typeOf expression =

--- a/src/OpenDiffix.Core/Expression.fs
+++ b/src/OpenDiffix.Core/Expression.fs
@@ -67,7 +67,7 @@ let typeOfAggregate fn args =
   | DiffixCount -> IntegerType
   | DiffixLowCount -> BooleanType
   | Sum -> RealType
-  | DiffixSum -> RealType
+  | DiffixSum -> args |> List.last |> typeOf
 
 /// Resolves the type of an expression.
 let rec typeOf expression =

--- a/src/OpenDiffix.Core/StarBucket.fs
+++ b/src/OpenDiffix.Core/StarBucket.fs
@@ -13,10 +13,7 @@ let private makeStarBucket aggregationContext anonymizationContext =
     aggregationContext.GroupingLabels
     |> Array.map (fun expr -> if Expression.typeOf expr = StringType then String "*" else Null)
 
-  let aggregators =
-    aggregationContext.Aggregators
-    |> Seq.map (fst >> Aggregator.create)
-    |> Seq.toArray
+  let aggregators = aggregationContext.Aggregators |> Seq.map Aggregator.create |> Seq.toArray
 
   let starBucket = Bucket.make group aggregators (Some anonymizationContext)
   // Not currently used, but may be in the future.


### PR DESCRIPTION
Closes #350 

I solved the issue of typing of the `sum` result dynamically, but this feels clunky. I'm wondering if there's an elegant way of extracting the type from the expression? We extract the length of aids dynamically, so I'm kinda guessing it's not easy, but still this makes me wonder.

I'm also unsure, whether `sum(arbitrary expression)` can be type stable, i.e. can we always now upfront, what `arbitrary expression`'s type will be, before starting to execute?