### PR TITLE
Pass args expressions to Aggregator.create

### DIFF
--- a/src/OpenDiffix.Core.Tests/Aggregator.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Aggregator.Tests.fs
@@ -49,16 +49,18 @@ let makeStandardArgs hasValueArg random length =
 /// Verifies that merging 2 separately aggregated sequences is equivalent
 /// to a single aggregation of those 2 sequences concatenated.
 let ensureConsistentMerging ctx fn sourceArgs destinationArgs =
-  let sourceAggregator = Aggregator.create fn
+  let DUMMY_ARGS = []
+
+  let sourceAggregator = Aggregator.create (fn, DUMMY_ARGS)
   sourceArgs |> List.iter sourceAggregator.Transition
 
-  let destinationAggregator = Aggregator.create fn
+  let destinationAggregator = Aggregator.create (fn, DUMMY_ARGS)
   destinationArgs |> List.iter destinationAggregator.Transition
 
   destinationAggregator.Merge sourceAggregator
   let mergedFinal = destinationAggregator.Final ctx
 
-  let replayedAggregator = Aggregator.create fn
+  let replayedAggregator = Aggregator.create (fn, DUMMY_ARGS)
   (destinationArgs @ sourceArgs) |> List.iter replayedAggregator.Transition
   let replayedFinal = replayedAggregator.Final ctx
 

--- a/src/OpenDiffix.Core.Tests/TestHelpers.fs
+++ b/src/OpenDiffix.Core.Tests/TestHelpers.fs
@@ -6,7 +6,7 @@ type DBFixture() =
     new OpenDiffix.CLI.SQLite.DataProvider(__SOURCE_DIRECTORY__ + "/../../data/data.sqlite") :> IDataProvider
 
 let evaluateAggregator ctx aggSpec args rows =
-  let aggregator = Aggregator.create aggSpec
+  let aggregator = Aggregator.create (aggSpec, args)
   let processor = fun row -> args |> List.map (Expression.evaluate row) |> aggregator.Transition
   List.iter processor rows
   aggregator.Final ctx

--- a/src/OpenDiffix.Core/Aggregator.fs
+++ b/src/OpenDiffix.Core/Aggregator.fs
@@ -300,7 +300,7 @@ let isAnonymizing ((fn, _args): AggregatorSpec) =
   | DiffixLowCount -> true
   | _ -> false
 
-let create (aggSpec: AggregatorSpec) : T =
+let create ((aggSpec, args): AggregatorSpec * AggregatorArgs) : T =
   match aggSpec with
   | Count, { Distinct = false } -> Count() :> T
   | Count, { Distinct = true } -> CountDistinct() :> T

--- a/src/OpenDiffix.Core/Executor.fs
+++ b/src/OpenDiffix.Core/Executor.fs
@@ -60,10 +60,10 @@ let private invokeHooks aggregationContext anonymizationContext hooks buckets =
 let private executeAggregate queryContext (childPlan, groupingLabels, aggregators, anonymizationContext) : seq<Row> =
   let groupingLabels = Array.ofList groupingLabels
   let aggregators = Utils.unpackAggregators aggregators
-  let aggSpecs, aggArgs = Array.unzip aggregators
+  let _aggSpecs, aggArgs = Array.unzip aggregators
 
   let makeBucket group anonymizationContext =
-    Bucket.make group (aggSpecs |> Array.map Aggregator.create) anonymizationContext
+    Bucket.make group (aggregators |> Array.map Aggregator.create) anonymizationContext
 
   let state = Dictionary<Row, Bucket>(Row.equalityComparer)
 

--- a/src/OpenDiffix.Core/StarBucket.fs
+++ b/src/OpenDiffix.Core/StarBucket.fs
@@ -13,10 +13,7 @@ let private makeStarBucket aggregationContext anonymizationContext =
     aggregationContext.GroupingLabels
     |> Array.map (fun expr -> if Expression.typeOf expr = StringType then String "*" else Null)
 
-  let aggregators =
-    aggregationContext.Aggregators
-    |> Seq.map (fst >> Aggregator.create)
-    |> Seq.toArray
+  let aggregators = aggregationContext.Aggregators |> Seq.map Aggregator.create |> Seq.toArray
 
   let starBucket = Bucket.make group aggregators (Some anonymizationContext)
   // Not currently used, but may be in the future.


### PR DESCRIPTION
The test code becomes a little dirty. When adding sum, it needs to create a const expr or whatever in order to allow inferring the type.

Feel free to cherry pick the commit so I can close this.