### PR TITLE
Add DiffixCountNoise, unoptimized, unanonymized

### DIFF
--- a/src/OpenDiffix.Core.Tests/Aggregator.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Aggregator.Tests.fs
@@ -144,6 +144,11 @@ let ``Merging DiffixCount`` () =
   DiffixCount |> testAnon NON_DISTINCT WITHOUT_VALUE_ARG
 
 [<Fact>]
+let ``Merging DiffixCountNoise`` () =
+  DiffixCountNoise |> testAnon NON_DISTINCT WITH_VALUE_ARG
+  DiffixCountNoise |> testAnon NON_DISTINCT WITHOUT_VALUE_ARG
+
+[<Fact>]
 let ``Merging DiffixSum`` () =
   DiffixSum |> testAnon NON_DISTINCT WITH_VALUE_ARG
 

--- a/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
@@ -376,13 +376,13 @@ type Tests(db: DBFixture) =
   let ``Fail on disallowed count`` () =
     assertTrustedQueryFails
       "SELECT count(age + id) FROM customers"
-      "Only count(*), count(column), count_noise(*), count_noise(column) and count(distinct column) are supported in anonymizing queries."
+      "Only count(column) is supported in anonymizing queries."
 
   [<Fact>]
   let ``Fail on disallowed count_noise`` () =
     assertTrustedQueryFails
       "SELECT count_noise(distinct age) FROM customers"
-      "Only count(*), count(column), count_noise(*), count_noise(column) and count(distinct column) are supported in anonymizing queries."
+      "count_noise(distinct column) is not currently supported."
 
   [<Fact>]
   let ``Fail on disallowed sum`` () =

--- a/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
@@ -353,13 +353,19 @@ type Tests(db: DBFixture) =
   [<Fact>]
   let ``Fail on unsupported aggregate in non-direct access level`` () =
     assertTrustedQueryFails
-      "SELECT diffix_count(age) FROM customers"
-      "Only count and sum aggregates are supported in anonymizing queries."
+      "SELECT diffix_count(*, age) FROM customers"
+      "Only count, count_noise and sum aggregates are supported in anonymizing queries."
+
+    assertTrustedQueryFails
+      "SELECT diffix_count_noise(*, age) FROM customers"
+      "Only count, count_noise and sum aggregates are supported in anonymizing queries."
 
   [<Fact>]
-  let ``Allow count(*), count(column) and count(distinct column)`` () =
+  let ``Allow count(*), count(column) (with noise versions) and count(distinct column)`` () =
     analyzeTrustedQuery "SELECT count(*) FROM customers" |> ignore
     analyzeTrustedQuery "SELECT count(age) FROM customers" |> ignore
+    analyzeTrustedQuery "SELECT count_noise(*) FROM customers" |> ignore
+    analyzeTrustedQuery "SELECT count_noise(age) FROM customers" |> ignore
     analyzeTrustedQuery "SELECT count(distinct age) FROM customers" |> ignore
 
   [<Fact>]
@@ -370,7 +376,13 @@ type Tests(db: DBFixture) =
   let ``Fail on disallowed count`` () =
     assertTrustedQueryFails
       "SELECT count(age + id) FROM customers"
-      "Only count(*), count(column) and count(distinct column) are supported in anonymizing queries."
+      "Only count(*), count(column), count_noise(*), count_noise(column) and count(distinct column) are supported in anonymizing queries."
+
+  [<Fact>]
+  let ``Fail on disallowed count_noise`` () =
+    assertTrustedQueryFails
+      "SELECT count_noise(distinct age) FROM customers"
+      "Only count(*), count(column), count_noise(*), count_noise(column) and count(distinct column) are supported in anonymizing queries."
 
   [<Fact>]
   let ``Fail on disallowed sum`` () =

--- a/src/OpenDiffix.Core.Tests/QueryEngine.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/QueryEngine.Tests.fs
@@ -75,11 +75,18 @@ type Tests(db: DBFixture) =
             { Name = "city"; Type = StringType }
             { Name = "count"; Type = IntegerType }
             { Name = "sum"; Type = RealType }
+            { Name = "count_noise"; Type = RealType }
           ]
-        Rows = [ [| String "Berlin"; Integer 10L; Integer 320L |]; [| String "Rome"; Integer 10L; Integer 300L |] ]
+        Rows =
+          [
+            [| String "Berlin"; Integer 10L; Integer 320L; Real 0.0 |]
+            [| String "Rome"; Integer 10L; Integer 300L; Real 0.0 |]
+          ]
       }
 
-    let queryResult = runQuery "SELECT city, count(distinct id), sum(age) FROM customers_small GROUP BY city"
+    let queryResult =
+      runQuery "SELECT city, count(distinct id), sum(age), count_noise(*) FROM customers_small GROUP BY city"
+
     queryResult |> should equal expected
 
   [<Fact>]

--- a/src/OpenDiffix.Core/Analyzer.fs
+++ b/src/OpenDiffix.Core/Analyzer.fs
@@ -45,6 +45,8 @@ let private mapFunctionExpression rangeColumns fn parsedArgs =
   (match fn, parsedArgs with
    | AggregateFunction (Count, aggregateArgs), [ ParserTypes.Star ] -> //
      AggregateFunction(Count, aggregateArgs), []
+   | AggregateFunction (CountNoise, aggregateArgs), [ ParserTypes.Star ] -> //
+     AggregateFunction(CountNoise, aggregateArgs), []
    | AggregateFunction (DiffixLowCount, aggregateArgs), parsedAids ->
      AggregateFunction(DiffixLowCount, aggregateArgs), [ mapAids parsedAids ]
    | AggregateFunction (DiffixCount, aggregateArgs), parsedArg :: parsedAids ->
@@ -56,6 +58,13 @@ let private mapFunctionExpression rangeColumns fn parsedArgs =
        | parsedExpr -> aggregateArgs, [ mapExpression rangeColumns parsedExpr ]
 
      AggregateFunction(DiffixCount, aggregateArgs), mapAids parsedAids :: args
+   | AggregateFunction (DiffixCountNoise, aggregateArgs), parsedArg :: parsedAids ->
+     let aggregateArgs, args =
+       match parsedArg with
+       | ParserTypes.Star -> aggregateArgs, []
+       | parsedExpr -> aggregateArgs, [ mapExpression rangeColumns parsedExpr ]
+
+     AggregateFunction(DiffixCountNoise, aggregateArgs), mapAids parsedAids :: args
    | AggregateFunction (DiffixSum, aggregateArgs), parsedArg :: parsedAids ->
      let aggregateArgs, args =
        match parsedArg with
@@ -293,6 +302,8 @@ let private compileAnonymizingAggregators aidColumnsExpression query =
     match expr with
     | FunctionExpr (AggregateFunction (Count, opts), args) ->
       FunctionExpr(AggregateFunction(DiffixCount, opts), aidColumnsExpression :: args)
+    | FunctionExpr (AggregateFunction (CountNoise, opts), args) ->
+      FunctionExpr(AggregateFunction(DiffixCountNoise, opts), aidColumnsExpression :: args)
     | other -> other |> map exprMapper
 
   query |> map exprMapper

--- a/src/OpenDiffix.Core/CommonTypes.fs
+++ b/src/OpenDiffix.Core/CommonTypes.fs
@@ -77,7 +77,9 @@ type SetFunction = | GenerateSeries
 
 type AggregateFunction =
   | Count
+  | CountNoise
   | DiffixCount
+  | DiffixCountNoise
   | DiffixLowCount
   | Sum
   | DiffixSum
@@ -317,8 +319,10 @@ module Function =
   let fromString name =
     match name with
     | "count" -> AggregateFunction(Count, AggregateOptions.Default)
+    | "count_noise" -> AggregateFunction(CountNoise, AggregateOptions.Default)
     | "sum" -> AggregateFunction(Sum, AggregateOptions.Default)
     | "diffix_count" -> AggregateFunction(DiffixCount, AggregateOptions.Default)
+    | "diffix_count_noise" -> AggregateFunction(DiffixCountNoise, AggregateOptions.Default)
     | "diffix_low_count" -> AggregateFunction(DiffixLowCount, AggregateOptions.Default)
     | "diffix_sum" -> AggregateFunction(DiffixSum, AggregateOptions.Default)
     | "+" -> ScalarFunction Add

--- a/src/OpenDiffix.Core/Expression.fs
+++ b/src/OpenDiffix.Core/Expression.fs
@@ -63,8 +63,10 @@ let typeOfSetFunction fn _args =
 /// Resolves the type of an aggregate function expression.
 let typeOfAggregate fn args =
   match fn with
-  | Count
+  | Count -> IntegerType
+  | CountNoise -> RealType
   | DiffixCount -> IntegerType
+  | DiffixCountNoise -> RealType
   | DiffixLowCount -> BooleanType
   | Sum -> RealType
   | DiffixSum -> args |> List.last |> typeOf

--- a/src/OpenDiffix.Core/QueryValidator.fs
+++ b/src/OpenDiffix.Core/QueryValidator.fs
@@ -30,21 +30,34 @@ let private validateAllowedAggregates query =
   |> visitAggregates (
     function
     | FunctionExpr (AggregateFunction (Count, _), _) -> ()
+    | FunctionExpr (AggregateFunction (CountNoise, _), _) -> ()
     | FunctionExpr (AggregateFunction (Sum, _), _) -> ()
     | FunctionExpr (AggregateFunction (_otherAggregate, _), _) ->
-      failwith "Only count and sum aggregates are supported in anonymizing queries."
+      failwith "Only count, count_noise and sum aggregates are supported in anonymizing queries."
     | _ -> ()
   )
 
 let private allowedCountUsage query =
+  let message =
+    "Only count(*), count(column), count_noise(*), count_noise(column)"
+    + " and count(distinct column) are supported in anonymizing queries."
+
+  let checkArgs =
+    function
+    | []
+    | [ ColumnReference _ ] -> ()
+    | _ -> failwith message
+
   query
   |> visitAggregates (
     function
-    | FunctionExpr (AggregateFunction (Count, _), args) ->
-      match args with
-      | []
-      | [ ColumnReference _ ] -> ()
-      | _ -> failwith "Only count(*), count(column) and count(distinct column) are supported in anonymizing queries."
+    | FunctionExpr (AggregateFunction (Count, opts), args) -> checkArgs args
+    | FunctionExpr (AggregateFunction (CountNoise, opts), args) ->
+      checkArgs args
+
+      match opts with
+      | { Distinct = true } -> failwith message
+      | _ -> ()
     | _ -> ()
   )
 


### PR DESCRIPTION
As title, this doesn't try to leverage the coexistence of `count(x)` and `count_noise(x)` in one query, just does the job twice.

I did some versions of handling the switch and the typing, this seems to work good enough, I'm not 100% sure though.