### PR TITLE
Add simpler count distinct AID variant to anonymizer

### DIFF
--- a/src/OpenDiffix.Core/Anonymizer.fs
+++ b/src/OpenDiffix.Core/Anonymizer.fs
@@ -326,6 +326,24 @@ let countDistinct
     |> fst
     |> (Math.roundAwayFromZero >> int64 >> (+) safeCount >> AnonymizedResult.Ok)
 
+/// Returns the noisy count of a single AID set.
+let countDistinctAid
+  (anonParams: AnonymizationParams)
+  (anonContext: AnonymizationContext)
+  (numAids: int)
+  (aidSeed: Hash)
+  =
+  let noise =
+    [ anonContext.BucketSeed; aidSeed ]
+    |> generateNoise anonParams.Salt "noise" anonParams.LayerNoiseSD
+
+  let noisyCount = (float numAids + noise) |> Math.roundAwayFromZero |> int64
+
+  if noisyCount < anonParams.Suppression.LowThreshold then
+    AnonymizedResult.NotEnoughAIDVs
+  else
+    AnonymizedResult.Ok noisyCount
+
 let count
   (anonParams: AnonymizationParams)
   (anonContext: AnonymizationContext)


### PR DESCRIPTION
I want to avoid the complex count distinct version in favor of a simple and specialized `count(distinct aid)` aggregator. Because I find it hard to understand the flattening code, I need feedback on this particular function before moving on with the histogram aggregate.