### PR TITLE
Make sure normalization of cast(1.01 as real) works

### DIFF
--- a/src/OpenDiffix.Core.Tests/Normalizer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Normalizer.Tests.fs
@@ -108,6 +108,12 @@ let ``normalize casts (2)`` () =
     "SELECT cast(age as real) as c FROM table"
 
 [<Fact>]
+let ``normalize casts (3)`` () =
+  equivalentQueries //
+    "SELECT cast(1.01 as real) AS c FROM table"
+    "SELECT 1.01 as c FROM table"
+
+[<Fact>]
 let ``normalize ranges (1)`` () =
   equivalentQueries //
     "SELECT round(age) AS x FROM table"

--- a/src/OpenDiffix.Core/Expression.fs
+++ b/src/OpenDiffix.Core/Expression.fs
@@ -204,6 +204,10 @@ let rec evaluateScalarFunction fn args =
   | Cast, [ Real r; String "text" ] -> r.ToString(doubleStyle) |> String
   | Cast, [ Boolean b; String "text" ] -> b.ToString().ToLower() |> String
 
+  | Cast, [ Integer i; String "integer" ] -> Integer i
+  | Cast, [ Real r; String "real" ] -> Real r
+  | Cast, [ Boolean b; String "boolean" ] -> Boolean b
+  | Cast, [ String s; String "string" ] -> String s
   | _ -> failwith $"Invalid usage of scalar function '%A{fn}'."
 
 /// Evaluates the result sequence of a set function invocation.


### PR DESCRIPTION
This line https://github.com/diffix/reference/blob/master/src/OpenDiffix.Core/Normalizer.fs#L19 evaluates the `cast(1.01 as real)` which used to be invalid cast.