### PR TITLE
sum_noise(col) and count_noise(distinct col)

### DIFF
--- a/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
@@ -357,35 +357,31 @@ type Tests(db: DBFixture) =
   let ``Fail on unsupported aggregate in non-direct access level`` () =
     assertTrustedQueryFails
       "SELECT diffix_count(*, age) FROM customers"
-      "Only count, count_noise and sum aggregates are supported in anonymizing queries."
+      "Aggregate not supported in anonymizing queries."
 
     assertTrustedQueryFails
       "SELECT diffix_count_noise(*, age) FROM customers"
-      "Only count, count_noise and sum aggregates are supported in anonymizing queries."
+      "Aggregate not supported in anonymizing queries."
 
   [<Fact>]
-  let ``Allow count(*), count(column) (with noise versions) and count(distinct column)`` () =
+  let ``Allow count(*), count(column) and count(distinct column) (with noise versions)`` () =
     analyzeTrustedQuery "SELECT count(*) FROM customers" |> ignore
     analyzeTrustedQuery "SELECT count(age) FROM customers" |> ignore
     analyzeTrustedQuery "SELECT count_noise(*) FROM customers" |> ignore
     analyzeTrustedQuery "SELECT count_noise(age) FROM customers" |> ignore
     analyzeTrustedQuery "SELECT count(distinct age) FROM customers" |> ignore
+    analyzeTrustedQuery "SELECT count_noise(distinct age) FROM customers" |> ignore
 
   [<Fact>]
-  let ``Allow sum(column)`` () =
+  let ``Allow sum(column) and sum_noise(column)`` () =
     analyzeTrustedQuery "SELECT sum(age) FROM customers" |> ignore
+    analyzeTrustedQuery "SELECT sum_noise(age) FROM customers" |> ignore
 
   [<Fact>]
   let ``Fail on disallowed count`` () =
     assertTrustedQueryFails
       "SELECT count(age + id) FROM customers"
       "Only count(column) is supported in anonymizing queries."
-
-  [<Fact>]
-  let ``Fail on disallowed count_noise`` () =
-    assertTrustedQueryFails
-      "SELECT count_noise(distinct age) FROM customers"
-      "count_noise(distinct column) is not currently supported."
 
   [<Fact>]
   let ``Fail on disallowed sum`` () =
@@ -395,6 +391,14 @@ type Tests(db: DBFixture) =
 
     assertTrustedQueryFails
       "SELECT sum(age + id) FROM customers"
+      "Only sum(column) is supported in anonymizing queries."
+
+    assertTrustedQueryFails
+      "SELECT sum_noise(distinct age) FROM customers"
+      "Only sum(column) is supported in anonymizing queries."
+
+    assertTrustedQueryFails
+      "SELECT sum_noise(age + id) FROM customers"
       "Only sum(column) is supported in anonymizing queries."
 
   [<Fact>]

--- a/src/OpenDiffix.Core.Tests/QueryEngine.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/QueryEngine.Tests.fs
@@ -76,16 +76,20 @@ type Tests(db: DBFixture) =
             { Name = "count"; Type = IntegerType }
             { Name = "sum"; Type = IntegerType }
             { Name = "count_noise"; Type = RealType }
+            { Name = "count_noise"; Type = RealType }
+            { Name = "count_noise"; Type = RealType }
+            { Name = "sum_noise"; Type = RealType }
           ]
         Rows =
           [
-            [| String "Berlin"; Integer 10L; Integer 295L; Real 0.0 |]
-            [| String "Rome"; Integer 10L; Integer 300L; Real 0.0 |]
+            [| String "Berlin"; Integer 10L; Integer 295L; Real 0.0; Real 0.0; Real 0.0; Real 0.0 |]
+            [| String "Rome"; Integer 10L; Integer 300L; Real 0.0; Real 0.0; Real 0.0; Real 0.0 |]
           ]
       }
 
     let queryResult =
-      runQuery "SELECT city, count(distinct id), sum(age), count_noise(*) FROM customers_small GROUP BY city"
+      runQuery
+        "SELECT city, count(distinct id), sum(age), count_noise(*), count_noise(id), count_noise(distinct id), sum_noise(age) FROM customers_small GROUP BY city"
 
     queryResult |> should equal expected
 

--- a/src/OpenDiffix.Core/CommonTypes.fs
+++ b/src/OpenDiffix.Core/CommonTypes.fs
@@ -82,7 +82,9 @@ type AggregateFunction =
   | DiffixCountNoise
   | DiffixLowCount
   | Sum
+  | SumNoise
   | DiffixSum
+  | DiffixSumNoise
   | Avg
   | DiffixAvg
 
@@ -322,10 +324,12 @@ module Function =
     match name with
     | "count" -> AggregateFunction(Count, AggregateOptions.Default)
     | "count_noise" -> AggregateFunction(CountNoise, AggregateOptions.Default)
+    | "sum_noise" -> AggregateFunction(SumNoise, AggregateOptions.Default)
     | "sum" -> AggregateFunction(Sum, AggregateOptions.Default)
     | "avg" -> AggregateFunction(Avg, AggregateOptions.Default)
     | "diffix_count" -> AggregateFunction(DiffixCount, AggregateOptions.Default)
     | "diffix_count_noise" -> AggregateFunction(DiffixCountNoise, AggregateOptions.Default)
+    | "diffix_sum_noise" -> AggregateFunction(DiffixSumNoise, AggregateOptions.Default)
     | "diffix_low_count" -> AggregateFunction(DiffixLowCount, AggregateOptions.Default)
     | "diffix_sum" -> AggregateFunction(DiffixSum, AggregateOptions.Default)
     | "diffix_avg" -> AggregateFunction(DiffixAvg, AggregateOptions.Default)

--- a/src/OpenDiffix.Core/Expression.fs
+++ b/src/OpenDiffix.Core/Expression.fs
@@ -69,8 +69,10 @@ let typeOfAggregate fn args =
   | DiffixCountNoise -> RealType
   | DiffixLowCount -> BooleanType
   | Sum -> args |> List.last |> typeOf
+  | SumNoise -> RealType
   | Avg -> RealType
   | DiffixSum -> args |> List.last |> typeOf
+  | DiffixSumNoise -> RealType
   | DiffixAvg -> RealType
 
 /// Resolves the type of an expression.


### PR DESCRIPTION
Closes #362, without `avg_noise` still pending discussion.

This is turning a little bit copy-pastive, but once we see whether we want to support `avg_noise` or not, we can think about some refactorings maybe.

I've spent some time testing it manually, but I didn't include any tests which would cover those exact new paths. I think we have enough coverage regardless, so no need to multiply this test code. Let me know, if you think otherwise.