### PR TITLE
Revert "Add support for simple `WHERE` clauses."

### DIFF
--- a/src/OpenDiffix.Core.Tests/Aggregator.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Aggregator.Tests.fs
@@ -87,7 +87,7 @@ let aggContext =
 
 let testAnonAggregatorMerging fn hasValueArg =
   let random = makeRandom fn hasValueArg
-  let ctx = aggContext, Some { BucketSeed = 0UL; BaseLabels = [] }
+  let ctx = aggContext, Some { BucketSeed = 0UL }
 
   let testPair numAids (length1, length2) =
     let makeArgs = makeAnonArgs hasValueArg random numAids

--- a/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
@@ -313,14 +313,11 @@ type Tests(db: DBFixture) =
   let assertDirectQueryFails = assertQueryFails Direct
   let assertUntrustedQueryFails = assertQueryFails PublishUntrusted
 
-  let assertSqlSeedWithFilter query (seedMaterials: string seq) baseLabels =
+  let assertSqlSeed query (seedMaterials: string seq) =
     let expectedSeed = Hash.strings 0UL seedMaterials
 
     (analyzeTrustedQuery query).AnonymizationContext
-    |> should equal (Some { BucketSeed = expectedSeed; BaseLabels = baseLabels })
-
-  let assertSqlSeed query (seedMaterials: string seq) =
-    assertSqlSeedWithFilter query seedMaterials []
+    |> should equal (Some { BucketSeed = expectedSeed })
 
   let assertEqualAnonContexts query1 query2 =
     (analyzeTrustedQuery query1).AnonymizationContext
@@ -389,18 +386,10 @@ type Tests(db: DBFixture) =
     analyzeTrustedQuery "SELECT count(*) FROM customers GROUP BY city HAVING length(city) > 3"
 
   [<Fact>]
-  let ``Reject unsupported WHERE clause in anonymizing subqueries`` () =
+  let ``Reject WHERE clause in anonymizing subqueries`` () =
     assertTrustedQueryFails
-      "SELECT count(*) FROM customers WHERE first_name <> ''"
-      "Only equalities between a generalization and a constant are allowed as filters in anonymizing queries."
-
-    assertTrustedQueryFails
-      "SELECT count(*) FROM customers WHERE age = 20 OR city = 'London'"
-      "Only equalities between a generalization and a constant are allowed as filters in anonymizing queries."
-
-  [<Fact>]
-  let ``Allow supported WHERE clause in anonymizing subqueries`` () =
-    analyzeTrustedQuery "SELECT count(*) FROM customers WHERE floor_by(age, 10) = 20 AND city = 'London'"
+      "SELECT count(*) FROM customers WHERE first_name=''"
+      "WHERE in anonymizing queries is not currently supported."
 
   [<Fact>]
   let ``Don't validate not anonymizing queries for unsupported anonymization features`` () =
@@ -452,11 +441,11 @@ type Tests(db: DBFixture) =
   let ``Detect queries with disallowed bucket functions calls`` () =
     assertTrustedQueryFails
       "SELECT round(2, age) from customers"
-      "Primary argument for a generalization expression has to be a simple column reference."
+      "Primary argument for a bucket function has to be a simple column reference."
 
     assertTrustedQueryFails
       "SELECT round(age, age) from customers"
-      "Secondary arguments for a generalization expression have to be constants."
+      "Secondary arguments for a bucket function have to be constants."
 
   [<Fact>]
   let ``Default SQL seed from non-anonymizing queries`` () =
@@ -500,19 +489,6 @@ type Tests(db: DBFixture) =
   [<Fact>]
   let ``Default SQL seed from non-anonymizing rounding cast`` () =
     assertNoAnonContext "SELECT cast(price AS integer) FROM products"
-
-  [<Fact>]
-  let ``SQL seed from single filter`` () =
-    assertSqlSeedWithFilter
-      "SELECT COUNT(*) FROM customers WHERE substring(city, 1, 2) = 'Lo'"
-      [ "substring,customers.city,1,2" ]
-      [ String "Lo" ]
-
-  let ``SQL seed from multiple filters`` () =
-    assertSqlSeedWithFilter
-      "SELECT COUNT(*) FROM customers WHERE age = 20 AND city = 'London'"
-      [ "customers.age"; "customers.city" ]
-      [ Integer 20L; String "London" ]
 
   [<Fact>]
   let ``Constant bucket labels are ignored`` () =

--- a/src/OpenDiffix.Core.Tests/Anonymizer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Anonymizer.Tests.fs
@@ -40,7 +40,7 @@ let anonParams =
 let aggContext = { AnonymizationParams = anonParams; GroupingLabels = [||]; Aggregators = [||] }
 
 let evaluateAggregator fn args =
-  evaluateAggregator (aggContext, Some { BucketSeed = 0UL; BaseLabels = [] }) fn args
+  evaluateAggregator (aggContext, Some { BucketSeed = 0UL }) fn args
 
 let distinctDiffixCount = DiffixCount, { AggregateOptions.Default with Distinct = true }
 let diffixCount = DiffixCount, { AggregateOptions.Default with Distinct = false }

--- a/src/OpenDiffix.Core.Tests/Executor.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Executor.Tests.fs
@@ -25,7 +25,7 @@ type Tests(db: DBFixture) =
   let countDistinct expression =
     FunctionExpr(AggregateFunction(Count, { Distinct = true; OrderBy = [] }), [ expression ])
 
-  let anonContext = { BucketSeed = 0UL; BaseLabels = [] }
+  let anonContext = { BucketSeed = 0UL }
 
   let queryContext = QueryContext.makeWithDataProvider db.DataProvider
 

--- a/src/OpenDiffix.Core.Tests/Expression.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Expression.Tests.fs
@@ -548,7 +548,7 @@ let aggContext =
   }
 
 let evaluateAggregator aggSpec args =
-  evaluateAggregator (aggContext, Some { BucketSeed = 0UL; BaseLabels = [] }) aggSpec args testRows
+  evaluateAggregator (aggContext, Some { BucketSeed = 0UL }) aggSpec args testRows
 
 [<Fact>]
 let ``evaluate scalar expressions`` () =

--- a/src/OpenDiffix.Core.Tests/NodeUtils.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/NodeUtils.Tests.fs
@@ -29,7 +29,7 @@ let selectQuery =
     Having = expression
     OrderBy = [ OrderBy(expression, Ascending, NullsFirst) ]
     Limit = None
-    AnonymizationContext = Some { BucketSeed = 0UL; BaseLabels = [] }
+    AnonymizationContext = Some { BucketSeed = 0UL }
   }
 
 let selectQueryNegative =
@@ -41,7 +41,7 @@ let selectQueryNegative =
     Having = negativeExpression
     OrderBy = [ OrderBy(negativeExpression, Ascending, NullsFirst) ]
     Limit = None
-    AnonymizationContext = Some { BucketSeed = 0UL; BaseLabels = [] }
+    AnonymizationContext = Some { BucketSeed = 0UL }
   }
 
 [<Fact>]

--- a/src/OpenDiffix.Core.Tests/Planner.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Planner.Tests.fs
@@ -26,7 +26,7 @@ let emptySelect =
     Having = constTrue
     OrderBy = []
     Limit = None
-    AnonymizationContext = Some { BucketSeed = 0UL; BaseLabels = [] }
+    AnonymizationContext = Some { BucketSeed = 0UL }
   }
 
 let column index =

--- a/src/OpenDiffix.Core.Tests/QueryEngine.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/QueryEngine.Tests.fs
@@ -198,19 +198,6 @@ type Tests(db: DBFixture) =
       "SELECT count(*) FROM customers_small GROUP BY city, city ORDER BY 1"
       "SELECT count(*) FROM customers_small GROUP BY city ORDER BY 1"
 
-  [<Fact>]
-  let ``Filtering and grouping doesn't change results`` () =
-    equivalentQueries
-      "SELECT count(*) FROM customers GROUP BY city HAVING city = 'Berlin'"
-      "SELECT count(*) FROM customers WHERE city = 'Berlin'"
-
-    equivalentQueries
-      "SELECT count(*) FROM customers GROUP BY city, round_by(age, 10) HAVING city = 'Berlin' AND round_by(age, 10) = 20"
-      "SELECT count(*) FROM customers WHERE city = 'Berlin' AND round_by(age, 10) = 20"
-
-    equivalentQueries
-      "SELECT count(*) FROM customers WHERE round_by(age, 10) = 20 GROUP BY city HAVING city = 'Berlin'"
-      "SELECT count(*) FROM customers WHERE city = 'Berlin' AND round_by(age, 10) = 20"
 
   [<Fact>]
   let ``Anonymizing subquery`` () =

--- a/src/OpenDiffix.Core/Aggregator.fs
+++ b/src/OpenDiffix.Core/Aggregator.fs
@@ -175,7 +175,7 @@ type private DiffixCount() =
       let anonContext = unwrapAnonContext anonContext
 
       let minCount =
-        if Array.isEmpty aggContext.GroupingLabels && List.isEmpty anonContext.BaseLabels then
+        if Array.isEmpty aggContext.GroupingLabels then
           0L
         else
           int64 aggContext.AnonymizationParams.Suppression.LowThreshold
@@ -236,7 +236,7 @@ type private DiffixCountDistinct() =
       let anonContext = unwrapAnonContext anonContext
 
       let minCount =
-        if Array.isEmpty aggContext.GroupingLabels && List.isEmpty anonContext.BaseLabels then
+        if Array.isEmpty aggContext.GroupingLabels then
           0L
         else
           int64 aggContext.AnonymizationParams.Suppression.LowThreshold

--- a/src/OpenDiffix.Core/Bucket.fs
+++ b/src/OpenDiffix.Core/Bucket.fs
@@ -4,15 +4,7 @@ let private addValuesToSeed seed (values: Value seq) =
   values |> Seq.map Value.toString |> Hash.strings seed
 
 let make group aggregators anonymizationContext =
-  let anonContextUpdater =
-    fun context ->
-      { context with
-          BucketSeed =
-            group
-            |> Array.toList
-            |> List.append context.BaseLabels
-            |> addValuesToSeed context.BucketSeed
-      }
+  let anonContextUpdater = fun context -> { context with BucketSeed = addValuesToSeed context.BucketSeed group }
 
   {
     Group = group

--- a/src/OpenDiffix.Core/CommonTypes.fs
+++ b/src/OpenDiffix.Core/CommonTypes.fs
@@ -205,7 +205,7 @@ type Plan =
 // Executor
 // ----------------------------------------------------------------
 
-type AnonymizationContext = { BucketSeed: Hash; BaseLabels: Value list }
+type AnonymizationContext = { BucketSeed: Hash }
 
 type AggregationContext =
   {

--- a/src/OpenDiffix.Core/NoiseLayers.fs
+++ b/src/OpenDiffix.Core/NoiseLayers.fs
@@ -33,7 +33,7 @@ let private collectSeedMaterials rangeColumns expression =
 // Public API
 // ----------------------------------------------------------------
 
-let computeSQLSeed rangeColumns normalizedBucketExpressions =
-  normalizedBucketExpressions
+let computeSQLSeed rangeColumns normalizedBucketLabelExpressions =
+  normalizedBucketLabelExpressions
   |> Seq.map (collectSeedMaterials rangeColumns)
   |> Hash.strings 0UL


### PR DESCRIPTION
This reverts commit 2b22d101425c5387b8af024e1acb63b1660ee216.
We keep simple filters support for Fir only.