### PR TITLE
Simplify integer flooring

### DIFF
--- a/src/OpenDiffix.Core/Aggregator.fs
+++ b/src/OpenDiffix.Core/Aggregator.fs
@@ -387,7 +387,7 @@ let private floorBy binSize count =
   match binSize with
   | None
   | Some 1L -> count
-  | Some binSize -> (float count / float binSize) |> floor |> int64 |> (*) binSize
+  | Some binSize -> (count / binSize) * binSize
 
 type private CountHistogram(binSize: int64 option) =
   let state = Dictionary<Value, int64>()


### PR DESCRIPTION
Integer division truncates anyway, making the float conversions redundant.