### PR TITLE
Enable star bucket and LED hooks in CLI app.

### DIFF
--- a/src/OpenDiffix.Core.Tests/Led.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Led.Tests.fs
@@ -107,8 +107,9 @@ let ``Merges taking precedence before star bucket hook`` () =
   // We get a hold of the star bucket results reference via side effects.
   let mutable suppressedAnonCount = Null
 
-  let pullHookResultsCallback aggCtx bucket =
-    suppressedAnonCount <- Bucket.finalizeAggregate 0 aggCtx bucket
+  let pullHookResultsCallback aggCtx starBucket buckets =
+    suppressedAnonCount <- Bucket.finalizeAggregate 0 aggCtx starBucket
+    buckets
 
   let starBucketHook = StarBucket.hook pullHookResultsCallback
 

--- a/src/OpenDiffix.Core.Tests/StarBucket.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/StarBucket.Tests.fs
@@ -33,8 +33,9 @@ let query =
 let ``Counts all suppressed buckets`` () =
   let mutable suppressedAnonCount = Null
 
-  let pullHookResultsCallback aggCtx bucket =
+  let pullHookResultsCallback aggCtx bucket buckets =
     suppressedAnonCount <- Bucket.finalizeAggregate 0 aggCtx bucket
+    buckets
 
   HookTestHelpers.run [ StarBucket.hook pullHookResultsCallback ] csv query
   |> ignore
@@ -45,8 +46,9 @@ let ``Counts all suppressed buckets`` () =
 let ``Counts all suppressed buckets, but suppresses the star bucket`` () =
   let mutable suppressedAnonCount = Null
 
-  let pullHookResultsCallback aggCtx bucket =
+  let pullHookResultsCallback aggCtx bucket buckets =
     suppressedAnonCount <- Bucket.finalizeAggregate 0 aggCtx bucket
+    buckets
 
   HookTestHelpers.run [ StarBucket.hook pullHookResultsCallback ] csvSuppressedStarBucket query
   |> ignore

--- a/src/OpenDiffix.Core/Executor.fs
+++ b/src/OpenDiffix.Core/Executor.fs
@@ -55,7 +55,10 @@ let private invokeHooks aggregationContext anonymizationContext hooks buckets =
   match anonymizationContext with
   | None -> buckets
   | Some anonymizationContext ->
-    List.fold (fun buckets hook -> hook aggregationContext anonymizationContext buckets) buckets hooks
+    if aggregationContext.GroupingLabels.Length > 0 then
+      List.fold (fun buckets hook -> hook aggregationContext anonymizationContext buckets) buckets hooks
+    else
+      buckets // don't run hooks for global bucket
 
 let private executeAggregate queryContext (childPlan, groupingLabels, aggregators, anonymizationContext) : seq<Row> =
   let groupingLabels = Array.ofList groupingLabels

--- a/src/OpenDiffix.Core/StarBucket.fs
+++ b/src/OpenDiffix.Core/StarBucket.fs
@@ -52,6 +52,6 @@ let hook
   // which won't be suppressed by itself (different noise seed). In such case,
   // we must enforce the suppression manually.
   if not isStarBucketLowCount && bucketsInStarBucket >= 2 then
-    callback aggregationContext starBucket
-
-  buckets
+    callback aggregationContext starBucket buckets
+  else
+    buckets


### PR DESCRIPTION
The `StarBucket.hook` callback is updated in order to support adding the star bucket to 
the output buckets. Hooks are not run anymore over the global bucket.

Closes #336.