### PR TITLE
Fix parsing of Floats like 1.101 and 1.lots-of-digits

### DIFF
--- a/src/OpenDiffix.Core.Tests/Parser.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Parser.Tests.fs
@@ -52,9 +52,14 @@ let ``Parses simple identifiers`` () =
 let ``Parses expressions`` () =
   [
     "1", Integer 1L
+    "-1", Integer -1L
     "1.1", Float 1.1
     "1.01", Float 1.01
     "1.001", Float 1.001
+    "1.101", Float 1.101
+    "-1.101", Float -1.101
+    "1.123456789012345678", Float 1.123456789012345678
+    "1.123456789012345678e18", Float 1.123456789012345678e18
     "1.0", Float 1.0
     "'hello'", String "hello"
     "true", Boolean true


### PR DESCRIPTION
I picked it up when using `WHERE x < 40.63` for debugging - it was parsing as `46.3`.

I've made an initial implementation fixing the one already there with some more code, but it started to become a considerable chunk to handle all the cases. So I redid the search and found the `numberLiteral` parser in `FParsec` - I hope this works.

To be sure we're covered, I added some extra test cases. Possibly repetitive since we're using `FParsec` now, but I think worth to have in case we stop doing so.