### PR TITLE
Fix avg/avg_noise when anonymized count is 0

### DIFF
--- a/src/OpenDiffix.Core.Tests/Expression.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Expression.Tests.fs
@@ -525,17 +525,20 @@ module DefaultFunctionsTests =
         Integer 1, Integer 2, Integer 1
         Real 1.1, Real 1.2, Real 1.1
         Boolean false, Boolean true, Boolean false
+        List [], List [ Integer 1 ], List []
         String "a", String "a", Null
         Integer 1, Integer 1, Null
         Real 1.1, Real 1.1, Null
         Boolean false, Boolean false, Null
-      ]
-
-    fails
-      NullIf
-      [ //
-        [ Boolean false; String "b" ]
-        [ List []; List [] ]
+        List [], List [], Null
+        Null, Null, Null
+        // cases leveraging the mixed integer/real binary coercion
+        Integer 1, Real 1.0, Null
+        Real 1.0, Integer 1, Null
+        Integer 1, Real 2.0, Real 1.0
+        Real 1.0, Integer 2, Real 1.0
+        // special cases, differing from PostgreSQL
+        String "a", Integer 1, String "a"
       ]
 
 let makeRows (ctor1, ctor2, ctor3) (rows: ('a * 'b * 'c) list) : Row list =

--- a/src/OpenDiffix.Core.Tests/Expression.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Expression.Tests.fs
@@ -516,6 +516,28 @@ module DefaultFunctionsTests =
         Null, String "integer", Null
       ]
 
+  [<Fact>]
+  let NullIf () =
+    runsBinary
+      NullIf
+      [ //
+        String "a", String "b", String "a"
+        Integer 1, Integer 2, Integer 1
+        Real 1.1, Real 1.2, Real 1.1
+        Boolean false, Boolean true, Boolean false
+        String "a", String "a", Null
+        Integer 1, Integer 1, Null
+        Real 1.1, Real 1.1, Null
+        Boolean false, Boolean false, Null
+      ]
+
+    fails
+      NullIf
+      [ //
+        [ Boolean false; String "b" ]
+        [ List []; List [] ]
+      ]
+
 let makeRows (ctor1, ctor2, ctor3) (rows: ('a * 'b * 'c) list) : Row list =
   rows |> List.map (fun (a, b, c) -> [| ctor1 a; ctor2 b; ctor3 c |])
 

--- a/src/OpenDiffix.Core/CommonTypes.fs
+++ b/src/OpenDiffix.Core/CommonTypes.fs
@@ -71,6 +71,7 @@ type ScalarFunction =
   | Concat
   | WidthBucket
   | Cast
+  | NullIf
 
 type ScalarArgs = Value list
 
@@ -361,6 +362,7 @@ module Function =
     | "||" -> ScalarFunction Concat
     | "width_bucket" -> ScalarFunction WidthBucket
     | "cast" -> ScalarFunction Cast
+    | "nullif" -> ScalarFunction NullIf
     | other -> failwith $"Unknown function `{other}`"
 
 module Table =

--- a/src/OpenDiffix.Core/Expression.fs
+++ b/src/OpenDiffix.Core/Expression.fs
@@ -54,7 +54,13 @@ let typeOfScalarFunction fn args =
       | Constant (String "real") -> RealType
       | Constant (String "boolean") -> BooleanType
       | _ -> failwith "Unsupported cast destination type name."
-  | NullIf -> args |> List.head |> typeOf
+  | NullIf ->
+    args
+    |> List.map typeOf
+    |> function
+      | [ IntegerType; RealType ] -> RealType
+      | [ RealType; IntegerType ] -> RealType
+      | argsTypes -> List.head argsTypes
 
 /// Resolves the type of a set function expression.
 let typeOfSetFunction fn _args =
@@ -216,11 +222,8 @@ let rec evaluateScalarFunction fn args =
   | Cast, [ Real r; String "text" ] -> r.ToString(doubleStyle) |> String
   | Cast, [ Boolean b; String "text" ] -> b.ToString().ToLower() |> String
 
-  | NullIf, [ Boolean x; Boolean y ] -> if x = y then Null else Boolean x
-  | NullIf, [ Integer x; Integer y ] -> if x = y then Null else Integer x
-  | NullIf, [ Real x; Real y ] -> if x = y then Null else Real x
-  | NullIf, [ String x; String y ] -> if x = y then Null else String x
-  | NullIf, [ Null; Null ] -> Null
+  | NullIf, [ x; y ] when x = y -> Null
+  | NullIf, [ x; y ] -> x
 
   | _ -> failwith $"Invalid usage of scalar function '%A{fn}'."
 

--- a/src/OpenDiffix.Core/Expression.fs
+++ b/src/OpenDiffix.Core/Expression.fs
@@ -54,6 +54,7 @@ let typeOfScalarFunction fn args =
       | Constant (String "real") -> RealType
       | Constant (String "boolean") -> BooleanType
       | _ -> failwith "Unsupported cast destination type name."
+  | NullIf -> args |> List.head |> typeOf
 
 /// Resolves the type of a set function expression.
 let typeOfSetFunction fn _args =
@@ -214,6 +215,12 @@ let rec evaluateScalarFunction fn args =
   | Cast, [ Integer i; String "text" ] -> i.ToString() |> String
   | Cast, [ Real r; String "text" ] -> r.ToString(doubleStyle) |> String
   | Cast, [ Boolean b; String "text" ] -> b.ToString().ToLower() |> String
+
+  | NullIf, [ Boolean x; Boolean y ] -> if x = y then Null else Boolean x
+  | NullIf, [ Integer x; Integer y ] -> if x = y then Null else Integer x
+  | NullIf, [ Real x; Real y ] -> if x = y then Null else Real x
+  | NullIf, [ String x; String y ] -> if x = y then Null else String x
+  | NullIf, [ Null; Null ] -> Null
 
   | _ -> failwith $"Invalid usage of scalar function '%A{fn}'."
 


### PR DESCRIPTION
Sibling of https://github.com/diffix/pg_diffix/pull/437.

The `nullif` has been added _without_ support for `Value.List`, which works in PostgreSQL. I started doing so, but realized, that validating the correct types (which PostgreSQL does) for lists is going to be pretty big and not worth it.