### PR TITLE
Recover and redistribute flattened outliers data.

### DIFF
--- a/queries-sample.json
+++ b/queries-sample.json
@@ -11,6 +11,7 @@
       "salt": [],
       "access_level": "publish_trusted",
       "strict": false,
+      "recover_outliers": true,
       "suppression": {
         "low_threshold": 2,
         "layer_s_d": 1,
@@ -39,6 +40,7 @@
       "salt": [],
       "access_level": "publish_trusted",
       "strict": false,
+      "recover_outliers": true,
       "suppression": {
         "low_threshold": 2,
         "layer_s_d": 1,
@@ -67,6 +69,7 @@
       "salt": [],
       "access_level": "publish_trusted",
       "strict": false,
+      "recover_outliers": true,
       "suppression": {
         "low_threshold": 2,
         "layer_s_d": 1,

--- a/src/OpenDiffix.CLI/Program.fs
+++ b/src/OpenDiffix.CLI/Program.fs
@@ -19,6 +19,7 @@ type CliArguments =
   | Access_Level of string
   | Strict of bool
   | Json
+  | Recover_Outliers of bool
 
   // Threshold values
   | [<Unique>] Outlier_Count of int * int
@@ -48,6 +49,9 @@ type CliArguments =
       | Strict _ ->
         "Controls whether the anonymization parameters must be checked strictly, i.e. to ensure safe minimum level of "
         + "anonymization. Defaults to `true`."
+      | Recover_Outliers _ ->
+        "If enabled, aggregated outliers are recovered and redistributed over the reported "
+        + "anonymized values, in order to minimize the total distortion for that column. Defaults to `true`."
       | Json -> "Outputs the query result as JSON. By default, output is in CSV format."
       | Outlier_Count _ ->
         "Interval used in the count aggregate to determine how many of the entities with the most extreme values "
@@ -131,6 +135,7 @@ let constructAnonParameters (parsedArgs: ParseResults<CliArguments>) : Anonymiza
     OutlierCount = parsedArgs.TryGetResult Outlier_Count |> toInterval
     TopCount = parsedArgs.TryGetResult Top_Count |> toInterval
     LayerNoiseSD = parsedArgs.TryGetResult Layer_Noise_SD |> toNoise
+    RecoverOutliers = parsedArgs.TryGetResult Recover_Outliers |> Option.defaultValue true
   }
 
 let getQuery (parsedArgs: ParseResults<CliArguments>) =

--- a/src/OpenDiffix.Core.Tests/Aggregator.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Aggregator.Tests.fs
@@ -112,7 +112,7 @@ let aggContext =
 
 let testAnonAggregatorMerging fn argType =
   let random = makeRandom fn argType
-  let ctx = aggContext, Some { BucketSeed = 0UL; BaseLabels = [] }
+  let ctx = aggContext, Some { BucketSeed = 0UL; BaseLabels = [] }, None
 
   let testPair numAids (length1, length2) =
     let makeArgs = makeAnonArgs argType random numAids
@@ -138,7 +138,7 @@ let testAnonAggregatorMerging fn argType =
 
 let testStandardAggregatorMerging fn argType =
   let random = makeRandom fn argType
-  let ctx = aggContext, None
+  let ctx = aggContext, None, None
 
   let testPair (length1, length2) =
     let makeArgs = makeStandardArgs argType random

--- a/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
@@ -282,6 +282,7 @@ type Tests(db: DBFixture) =
       OutlierCount = { Lower = 1; Upper = 1 }
       TopCount = { Lower = 1; Upper = 1 }
       LayerNoiseSD = 0.
+      RecoverOutliers = true
     }
 
   let queryContext accessLevel =

--- a/src/OpenDiffix.Core.Tests/Anonymizer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Anonymizer.Tests.fs
@@ -45,11 +45,11 @@ let anonParams =
 let aggContext = { AnonymizationParams = anonParams; GroupingLabels = [||]; Aggregators = [||] }
 
 let evaluateAggregator fn args =
-  TestHelpers.evaluateAggregator (aggContext, Some { BucketSeed = 0UL; BaseLabels = [] }) fn args
+  TestHelpers.evaluateAggregator (aggContext, Some { BucketSeed = 0UL; BaseLabels = [] }, None) fn args
 
 let evaluateAggregatorNoisy fn args =
   let aggContextNoisy = { aggContext with AnonymizationParams = { anonParams with LayerNoiseSD = 1. } }
-  TestHelpers.evaluateAggregator (aggContextNoisy, Some { BucketSeed = 0UL; BaseLabels = [] }) fn args
+  TestHelpers.evaluateAggregator (aggContextNoisy, Some { BucketSeed = 0UL; BaseLabels = [] }, None) fn args
 
 let distinctDiffixCount = DiffixCount, { AggregateOptions.Default with Distinct = true }
 let diffixCount = DiffixCount, AggregateOptions.Default

--- a/src/OpenDiffix.Core.Tests/Anonymizer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Anonymizer.Tests.fs
@@ -40,6 +40,7 @@ let anonParams =
     OutlierCount = { Lower = 1; Upper = 1 }
     TopCount = { Lower = 1; Upper = 1 }
     LayerNoiseSD = 0.
+    RecoverOutliers = true
   }
 
 let aggContext = { AnonymizationParams = anonParams; GroupingLabels = [||]; Aggregators = [||] }

--- a/src/OpenDiffix.Core.Tests/Executor.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Executor.Tests.fs
@@ -86,12 +86,7 @@ type Tests(db: DBFixture) =
     let condition = Expression.makeFunction Equals [ column products 1; Constant(String "xxx") ]
 
     let plan =
-      Plan.Aggregate(
-        Plan.Filter(Plan.Scan(products, [ 1 ]), condition),
-        [ nameLength ],
-        [ countStar ],
-        Some anonContext
-      )
+      Plan.Aggregate(Plan.Filter(Plan.Scan(products, [ 1 ]), condition), [ nameLength ], [ countStar ], None)
 
     let expected: Row list = []
     plan |> execute |> should equal expected
@@ -152,11 +147,12 @@ type Tests(db: DBFixture) =
     let priceReal = Expression.makeFunction CeilBy [ price; Constant(Real 1000.0) ]
     let idColumn = column products 0
     let diffixCount = Expression.makeAggregate DiffixCount [ ListExpr [ idColumn ] ]
+    let diffixLowCount = Expression.makeAggregate DiffixLowCount [ ListExpr [ idColumn ] ]
     let scanProducts = Plan.Scan(products, [ 0; 2 ])
 
     let makePlan groupBy =
       Plan.Project(
-        Plan.Aggregate(scanProducts, [ groupBy ], [ diffixCount ], Some anonContext),
+        Plan.Aggregate(scanProducts, [ groupBy ], [ diffixCount; diffixLowCount ], Some anonContext),
         [ ColumnReference(1, IntegerType) ]
       )
 

--- a/src/OpenDiffix.Core.Tests/Expression.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Expression.Tests.fs
@@ -548,7 +548,7 @@ let aggContext =
   }
 
 let evaluateAggregator aggSpec args =
-  evaluateAggregator (aggContext, Some { BucketSeed = 0UL; BaseLabels = [] }) aggSpec args testRows
+  evaluateAggregator (aggContext, Some { BucketSeed = 0UL; BaseLabels = [] }, None) aggSpec args testRows
 
 [<Fact>]
 let ``evaluate scalar expressions`` () =

--- a/src/OpenDiffix.Core.Tests/HookTestHelpers.fs
+++ b/src/OpenDiffix.Core.Tests/HookTestHelpers.fs
@@ -12,6 +12,7 @@ let private noiselessAnonParams: AnonymizationParams =
     OutlierCount = { Lower = 1; Upper = 1 }
     TopCount = { Lower = 1; Upper = 1 }
     LayerNoiseSD = 0.
+    RecoverOutliers = true
   }
 
 let private csvReader (csv: string) =

--- a/src/OpenDiffix.Core.Tests/QueryEngine.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/QueryEngine.Tests.fs
@@ -23,6 +23,7 @@ type Tests(db: DBFixture) =
       OutlierCount = { Lower = 1; Upper = 1 }
       TopCount = { Lower = 1; Upper = 1 }
       LayerNoiseSD = 0.
+      RecoverOutliers = true
     }
 
   let noisyAnonParams = { AnonymizationParams.Default with TableSettings = tableSettings }

--- a/src/OpenDiffix.Core.Tests/QueryEngine.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/QueryEngine.Tests.fs
@@ -289,17 +289,13 @@ type Tests(db: DBFixture) =
       "SELECT count(*) FROM customers_small GROUP BY city ORDER BY 1"
 
   [<Fact>]
-  let ``Filtering and grouping doesn't change results`` () =
+  let ``Equivalent filtering and grouping doesn't change seed`` () =
     equivalentQueries
-      "SELECT count(*) FROM customers GROUP BY city HAVING city = 'Berlin'"
+      "SELECT count(*) FROM customers WHERE city = 'Berlin' GROUP BY city"
       "SELECT count(*) FROM customers WHERE city = 'Berlin'"
 
     equivalentQueries
-      "SELECT count(*) FROM customers GROUP BY city, round_by(age, 10) HAVING city = 'Berlin' AND round_by(age, 10) = 20"
-      "SELECT count(*) FROM customers WHERE city = 'Berlin' AND round_by(age, 10) = 20"
-
-    equivalentQueries
-      "SELECT count(*) FROM customers WHERE round_by(age, 10) = 20 GROUP BY city HAVING city = 'Berlin'"
+      "SELECT count(*) FROM customers WHERE city = 'Berlin' AND round_by(age, 10) = 20 GROUP BY city, round_by(age, 10)"
       "SELECT count(*) FROM customers WHERE city = 'Berlin' AND round_by(age, 10) = 20"
 
   [<Fact>]

--- a/src/OpenDiffix.Core/Aggregator.fs
+++ b/src/OpenDiffix.Core/Aggregator.fs
@@ -52,12 +52,12 @@ let private increaseContribution valueIncrease aidValue (aidMap: Dictionary<AidH
 
 let private mergeOutliers outliers (contributions: Anonymizer.ContributionsState array) =
   outliers
-  |> Array.iteri (fun aidIndex aidOutliers ->
-    let aidContributions = contributions.[aidIndex].AidContributions
+  |> Array.iteri (fun aidInstanceIndex aidOutliers ->
+    let aidContributions = contributions.[aidInstanceIndex].AidContributions
 
     aidOutliers
-    |> Array.iter (fun (aid, contribution) ->
-      aidContributions.[aid] <- (aidContributions |> Dictionary.getOrDefault aid 0.0) + contribution
+    |> Array.iter (fun (aid, droppedContribution) ->
+      aidContributions.[aid] <- (aidContributions |> Dictionary.getOrDefault aid 0.0) + droppedContribution
     )
   )
 

--- a/src/OpenDiffix.Core/Aggregator.fs
+++ b/src/OpenDiffix.Core/Aggregator.fs
@@ -52,8 +52,8 @@ let private increaseContribution valueIncrease aidValue (aidMap: Dictionary<AidH
 
 let private mergeOutliers outliers (contributions: Anonymizer.ContributionsState array) =
   outliers
-  |> Array.iteri (fun i aidOutliers ->
-    let aidContributions = contributions.[i].AidContributions
+  |> Array.iteri (fun aidIndex aidOutliers ->
+    let aidContributions = contributions.[aidIndex].AidContributions
 
     aidOutliers
     |> Array.iter (fun (aid, contribution) ->

--- a/src/OpenDiffix.Core/Bucket.fs
+++ b/src/OpenDiffix.Core/Bucket.fs
@@ -28,8 +28,8 @@ let getAttribute attr bucket =
 let putAttribute attr value bucket = bucket.Attributes.[attr] <- value
 
 let isLowCount lowCountIndex bucket aggregationContext =
-  bucket.Aggregators.[lowCountIndex].Final(aggregationContext, bucket.AnonymizationContext)
+  bucket.Aggregators.[lowCountIndex].Final(aggregationContext, bucket.AnonymizationContext, None)
   |> Value.unwrapBoolean
 
 let finalizeAggregate index aggregationContext bucket =
-  bucket.Aggregators.[index].Final(aggregationContext, bucket.AnonymizationContext)
+  bucket.Aggregators.[index].Final(aggregationContext, bucket.AnonymizationContext, None)

--- a/src/OpenDiffix.Core/CommonTypes.fs
+++ b/src/OpenDiffix.Core/CommonTypes.fs
@@ -167,6 +167,8 @@ type AnonymizationParams =
     OutlierCount: Interval
     TopCount: Interval
     LayerNoiseSD: float
+
+    RecoverOutliers: bool
   }
   static member Default =
     {
@@ -178,6 +180,7 @@ type AnonymizationParams =
       OutlierCount = Interval.Default
       TopCount = Interval.Default
       LayerNoiseSD = 1.0
+      RecoverOutliers = true
     }
 
 // ----------------------------------------------------------------

--- a/src/OpenDiffix.Core/CommonTypes.fs
+++ b/src/OpenDiffix.Core/CommonTypes.fs
@@ -235,7 +235,8 @@ type IAggregator =
   // Merge state with that of a compatible aggregator
   abstract Merge : IAggregator -> unit
   // Extract the final value of the aggregation function from the state
-  abstract Final : AggregationContext * AnonymizationContext option -> Value
+  // Also merges unused data from outliers into the target aggregator, if any
+  abstract Final : AggregationContext * AnonymizationContext option * IAggregator option -> Value
 
 type AggregatorSpec = AggregateFunction * AggregateOptions
 type AggregatorArgs = Expression list

--- a/src/OpenDiffix.Core/Executor.fs
+++ b/src/OpenDiffix.Core/Executor.fs
@@ -51,14 +51,103 @@ let private executeLimit queryContext (childPlan, amount) : seq<Row> =
 
   childPlan |> execute queryContext |> Seq.truncate (int amount)
 
-let private invokeHooks aggregationContext anonymizationContext hooks buckets =
-  match anonymizationContext with
-  | None -> buckets
-  | Some anonymizationContext ->
-    if aggregationContext.GroupingLabels.Length > 0 then
-      List.fold (fun buckets hook -> hook aggregationContext anonymizationContext buckets) buckets hooks
-    else
-      buckets // don't run hooks for global bucket
+let private accumulateAbs accumulator value =
+  match value with
+  | Integer value -> accumulator + abs (float value)
+  | Real value -> accumulator + abs value
+  | _ -> accumulator
+
+// Returns a function that proportionally redistributes the aggregrated outliers data over the individual values in a column.
+let private makeColumnTweaker total outliersAggregate =
+  match total > 0.0, outliersAggregate with
+  | true, Integer outliersAggregate ->
+    function
+    | Integer i ->
+      let tweakFactor = 1.0 + float outliersAggregate / total
+      Integer(int64 (Math.roundAwayFromZero (float i * tweakFactor)))
+    | Null -> Null
+    | _ -> failwith "Unexpected value type in `integer` column."
+  | true, Real outliersAggregate ->
+    function
+    | Real r ->
+      let tweakFactor = 1.0 + float outliersAggregate / total
+      Real(r * tweakFactor)
+    | Null -> Null
+    | _ -> failwith "Unexpected value type in `real` column."
+  | _ -> id
+
+// Recovers dropped outliers data while finalizing aggregated values and proportionally redistributes it over the
+// non-suppressed anonymized values, in order to minimize the total distortion per column.
+let private finalizeAggregratesAndRedistributeOutliers
+  (aggregationContext: AggregationContext)
+  anonymizationContext
+  buckets
+  : Row seq =
+  let outliersAggregators = aggregationContext.Aggregators |> Array.map Aggregator.create
+  let totals = Array.create aggregationContext.Aggregators.Length 0.0
+  let lowCountIndex = AggregationContext.lowCountIndex aggregationContext
+
+  // Finalize aggregrated values, gather dropped outliers data and compute column totals.
+  let rows =
+    buckets
+    |> Seq.map (fun bucket ->
+      let isLowCount =
+        bucket
+        |> Bucket.finalizeAggregate lowCountIndex aggregationContext
+        |> Value.unwrapBoolean
+
+      let finalizer =
+        if isLowCount then
+          fun _i (agg: IAggregator) -> agg.Final(aggregationContext, bucket.AnonymizationContext, None)
+        else
+          fun i (agg: IAggregator) ->
+            let value = agg.Final(aggregationContext, bucket.AnonymizationContext, Some outliersAggregators.[i])
+            totals.[i] <- accumulateAbs totals.[i] value
+            value
+
+      Array.append bucket.Group (Array.mapi finalizer bucket.Aggregators)
+    )
+    |> Seq.toArray
+
+  // Force global aggregration and anonymization contexts for aggregrating outliers.
+  let outliersAggregationContext = { aggregationContext with GroupingLabels = [||] }
+  let outliersAnonymizationContext = { anonymizationContext with BaseLabels = [] }
+
+  // Create a value tweaker for each column that minimizes the total distortion of that column.
+  let columnTweakers =
+    outliersAggregators
+    |> Array.mapi (fun i agg ->
+      makeColumnTweaker totals.[i] (agg.Final(outliersAggregationContext, Some outliersAnonymizationContext, None))
+    )
+
+  // Apply column tweakers to non-suppressed rows.
+  rows
+  |> Seq.filter (fun row -> not (Value.unwrapBoolean row.[lowCountIndex + aggregationContext.GroupingLabels.Length]))
+  |> Seq.iter (fun row ->
+    columnTweakers
+    |> Array.iteri (fun columnIndex tweaker ->
+      let valueIndex = columnIndex + aggregationContext.GroupingLabels.Length
+      row.[valueIndex] <- tweaker row.[valueIndex]
+    )
+  )
+
+  rows
+
+let private finalizeBuckets aggregationContext anonymizationContext hooks buckets =
+  // Invoking hooks and redistributing outliers require that a `DiffixLowCount` aggregrator is present,
+  // which only happens during non-global anonymized aggregration.
+  match aggregationContext, anonymizationContext with
+  | { GroupingLabels = groupingLabels }, Some anonymizationContext when groupingLabels.Length > 0 ->
+    List.fold (fun buckets hook -> hook aggregationContext anonymizationContext buckets) buckets hooks
+    |> finalizeAggregratesAndRedistributeOutliers aggregationContext anonymizationContext
+  | _ -> // finalize aggregrates without invoking hooks or redistributing outliers
+    buckets
+    |> Seq.map (fun bucket ->
+      Array.append
+        bucket.Group
+        (bucket.Aggregators
+         |> Array.map (fun agg -> agg.Final(aggregationContext, bucket.AnonymizationContext, None)))
+    )
 
 let private executeAggregate queryContext (childPlan, groupingLabels, aggregators, anonymizationContext) : seq<Row> =
   let groupingLabels = Array.ofList groupingLabels
@@ -100,13 +189,7 @@ let private executeAggregate queryContext (childPlan, groupingLabels, aggregator
 
   state
   |> Seq.map (fun pair -> pair.Value)
-  |> invokeHooks aggregationContext anonymizationContext queryContext.PostAggregationHooks
-  |> Seq.map (fun bucket ->
-    Array.append
-      bucket.Group
-      (bucket.Aggregators
-       |> Array.map (fun agg -> agg.Final(aggregationContext, bucket.AnonymizationContext)))
-  )
+  |> finalizeBuckets aggregationContext anonymizationContext queryContext.PostAggregationHooks
 
 let private executeJoin executionContext (leftPlan, rightPlan, joinType, on) =
   let isOuterJoin, outerPlan, innerPlan, rowJoiner =

--- a/src/OpenDiffix.Core/Executor.fs
+++ b/src/OpenDiffix.Core/Executor.fs
@@ -57,7 +57,7 @@ let private accumulateAbs accumulator value =
   | Real value -> accumulator + abs value
   | _ -> accumulator
 
-// Returns a function that proportionally redistributes the aggregrated outliers data over the individual values in a column.
+// Returns a function that proportionally redistributes the aggregated outliers data over the individual values in a column.
 let private makeColumnTweaker total outliersAggregate =
   match total > 0.0, outliersAggregate with
   | true, Integer outliersAggregate ->
@@ -78,7 +78,7 @@ let private makeColumnTweaker total outliersAggregate =
 
 // Recovers dropped outliers data while finalizing aggregated values and proportionally redistributes it over the
 // non-suppressed anonymized values, in order to minimize the total distortion per column.
-let private finalizeAggregratesAndRedistributeOutliers
+let private finalizeAggregatesAndRedistributeOutliers
   (aggregationContext: AggregationContext)
   anonymizationContext
   buckets
@@ -87,7 +87,7 @@ let private finalizeAggregratesAndRedistributeOutliers
   let totals = Array.create aggregationContext.Aggregators.Length 0.0
   let lowCountIndex = AggregationContext.lowCountIndex aggregationContext
 
-  // Finalize aggregrated values, gather dropped outliers data and compute column totals.
+  // Finalize aggregated values, gather dropped outliers data and compute column totals.
   let rows =
     buckets
     |> Seq.map (fun bucket ->
@@ -109,7 +109,7 @@ let private finalizeAggregratesAndRedistributeOutliers
     )
     |> Seq.toArray
 
-  // Force global aggregration and anonymization contexts for aggregrating outliers.
+  // Force global aggregation and anonymization contexts for aggregating outliers.
   let outliersAggregationContext = { aggregationContext with GroupingLabels = [||] }
   let outliersAnonymizationContext = { anonymizationContext with BaseLabels = [] }
 
@@ -134,13 +134,13 @@ let private finalizeAggregratesAndRedistributeOutliers
   rows
 
 let private finalizeBuckets aggregationContext anonymizationContext hooks buckets =
-  // Invoking hooks and redistributing outliers require that a `DiffixLowCount` aggregrator is present,
-  // which only happens during non-global anonymized aggregration.
+  // Invoking hooks and redistributing outliers require that a `DiffixLowCount` aggregator is present,
+  // which only happens during non-global anonymized aggregation.
   match aggregationContext, anonymizationContext with
   | { GroupingLabels = groupingLabels }, Some anonymizationContext when groupingLabels.Length > 0 ->
     List.fold (fun buckets hook -> hook aggregationContext anonymizationContext buckets) buckets hooks
-    |> finalizeAggregratesAndRedistributeOutliers aggregationContext anonymizationContext
-  | _ -> // finalize aggregrates without invoking hooks or redistributing outliers
+    |> finalizeAggregatesAndRedistributeOutliers aggregationContext anonymizationContext
+  | _ -> // finalize aggregates without invoking hooks or redistributing outliers
     buckets
     |> Seq.map (fun bucket ->
       Array.append


### PR DESCRIPTION
Data dropped during flattening is recovered and proportionally redistributed over the anonymized buckets, in order to minimize the total distortion per column.