### PR TITLE
Have a `cast` expression not impact the inferred column name

### DIFF
--- a/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
@@ -138,6 +138,23 @@ let ``Selecting columns from a table`` () =
     }
 
 [<Fact>]
+let ``Selecting cast columns from a table`` () =
+  testParsedQuery
+    "SELECT cast(bool_col, 'text') FROM table"
+    { defaultQuery with
+        TargetList =
+          [
+            {
+              Expression =
+                FunctionExpr(ScalarFunction Cast, [ ColumnReference(3, BooleanType); Constant(String "text") ])
+              // Should not be `cast`.
+              Alias = "bool_col"
+              Tag = RegularTargetEntry
+            }
+          ]
+    }
+
+[<Fact>]
 let ``SELECT with alias, function, aggregate, GROUP BY, and WHERE-clause`` () =
   let query =
     @"

--- a/src/OpenDiffix.Core/Analyzer.fs
+++ b/src/OpenDiffix.Core/Analyzer.fs
@@ -22,9 +22,10 @@ let rec private resolveColumn rangeColumns tableName columnName =
   | [] -> failwith $"Column %s{label} not found in query range"
   | _ -> failwith $"Ambiguous reference to column %s{label} in query range"
 
-let private expressionName parsedExpr =
+let rec private expressionName parsedExpr =
   match parsedExpr with
   | ParserTypes.Identifier (_, columnName) -> columnName
+  | ParserTypes.Function ("cast", arg :: _) -> expressionName arg
   | ParserTypes.Function (name, _args) -> name
   | _ -> ""
 


### PR DESCRIPTION
In PostgreSQL when you `cast`, the column doesn't get called `cast`, e.g.:

```
prop_test=# SELECT cast(date_trunc('year', cast(last_seen as timestamp)) as text) FROM customers  GROUP BY 1;
     date_trunc      
---------------------
 2012-01-01 00:00:00
```

Let's have the same in `reference`