### PR TITLE
Fix parser to recognize cast as timestamp 

### DIFF
--- a/src/OpenDiffix.CLI/SQLiteDataProvider.fs
+++ b/src/OpenDiffix.CLI/SQLiteDataProvider.fs
@@ -64,7 +64,6 @@ let private columnTypeFromString =
   | "text" -> StringType
   | "boolean" -> BooleanType
   | "real" -> RealType
-  | "datetime" -> TimestampType
   | other -> UnknownType other
 
 type DataProvider(dbPath: string) =

--- a/src/OpenDiffix.Core/Parser.fs
+++ b/src/OpenDiffix.Core/Parser.fs
@@ -78,7 +78,12 @@ module QueryParser =
     simpleIdentifier .>> spaces .>>. inParenthesis (commaSeparated expr) .>> spaces
     |>> fun (funName, exprs) -> Function(funName.ToLower(), exprs)
 
-  let typeName = word "text" <|> word "integer" <|> word "real" <|> word "boolean"
+  let typeName =
+    word "text"
+    <|> word "integer"
+    <|> word "real"
+    <|> word "boolean"
+    <|> word "timestamp"
 
   let castExpression =
     word "cast" >>. inParenthesis (expr .>> word "as" .>>. typeName) .>> spaces


### PR DESCRIPTION
A small detail that slipped through. I thought `cast(something as type)` was not supported syntax but then realized it's just for `as timestamp`.

Bonus: removing a brainfart change from my earlier PR, no idea where this came from.