### PR TITLE
Support `extract(... from ...)`

### DIFF
--- a/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Analyzer.Tests.fs
@@ -633,6 +633,12 @@ type Tests(db: DBFixture) =
     assertNoAnonContext "SELECT cast(price AS integer) FROM products"
 
   [<Fact>]
+  let ``SQL seed for extract and date_part`` () =
+    let expected = [ "extract,dow,customers.last_seen" ]
+    assertSqlSeed "SELECT extract(dow from cast(last_seen as timestamp)) FROM customers" expected
+    assertSqlSeed "SELECT date_part('dow', cast(last_seen as timestamp)) FROM customers" expected
+
+  [<Fact>]
   let ``SQL seed from single filter`` () =
     assertSqlSeedWithFilter
       "SELECT COUNT(*) FROM customers WHERE substring(city, 1, 2) = 'Lo'"

--- a/src/OpenDiffix.Core.Tests/Expression.Tests.fs
+++ b/src/OpenDiffix.Core.Tests/Expression.Tests.fs
@@ -576,6 +576,37 @@ module DefaultFunctionsTests =
         [ String "secondz"; Timestamp(System.DateTime(2113, 2, 6)) ]
       ]
 
+  [<Fact>]
+  let Extract () =
+    runsBinary
+      Extract
+      [ //
+        String "second", Timestamp(System.DateTime(2113, 2, 8, 13, 56, 41, 123)), Real 41.0
+        String "epoch", Timestamp(System.DateTime(2113, 2, 8, 13, 56, 41, 123)), Real 4516005401.123
+        String "minute", Timestamp(System.DateTime(2113, 2, 8, 13, 56, 41)), Real 56.0
+        String "hour", Timestamp(System.DateTime(2113, 2, 8, 13, 56, 41)), Real 13.0
+        String "day", Timestamp(System.DateTime(2113, 2, 8, 13, 56, 41)), Real 8.0
+        String "dow", Timestamp(System.DateTime(2113, 2, 5, 13, 56, 41)), Real 0.0
+        String "doy", Timestamp(System.DateTime(2113, 2, 8, 13, 56, 41)), Real 39.0
+        String "isodow", Timestamp(System.DateTime(2113, 2, 5, 13, 56, 41)), Real 7.0
+        String "week", Timestamp(System.DateTime(2113, 2, 8, 13, 56, 41)), Real 6.0
+        String "month", Timestamp(System.DateTime(2113, 2, 8, 13, 56, 41)), Real 2.0
+        String "quarter", Timestamp(System.DateTime(2113, 5, 8)), Real 2.0
+        String "year", Timestamp(System.DateTime(2113, 2, 8, 13, 56, 41)), Real 2113.0
+        String "isoyear", Timestamp(System.DateTime(2113, 1, 1, 13, 56, 41)), Real 2112.0
+        String "decade", Timestamp(System.DateTime(2113, 2, 8, 13, 56, 41)), Real 211.0
+        String "century", Timestamp(System.DateTime(2113, 2, 8, 13, 56, 41)), Real 22.0
+        String "millennium", Timestamp(System.DateTime(2113, 2, 8, 13, 56, 41)), Real 3.0
+        String "century", Timestamp(System.DateTime(2000, 2, 8, 13, 56, 41)), Real 20.0
+        String "millennium", Timestamp(System.DateTime(2000, 2, 8, 13, 56, 41)), Real 2.0
+      ]
+
+    fails
+      Extract
+      [ //
+        [ String "secondz"; Timestamp(System.DateTime(2113, 2, 6)) ]
+      ]
+
 let makeRows (ctor1, ctor2, ctor3) (rows: ('a * 'b * 'c) list) : Row list =
   rows |> List.map (fun (a, b, c) -> [| ctor1 a; ctor2 b; ctor3 c |])
 

--- a/src/OpenDiffix.Core/CommonTypes.fs
+++ b/src/OpenDiffix.Core/CommonTypes.fs
@@ -75,6 +75,7 @@ type ScalarFunction =
   | Cast
   | NullIf
   | DateTrunc
+  | Extract
 
 type ScalarArgs = Value list
 
@@ -372,6 +373,8 @@ module Function =
     | "cast" -> ScalarFunction Cast
     | "nullif" -> ScalarFunction NullIf
     | "date_trunc" -> ScalarFunction DateTrunc
+    | "extract"
+    | "date_part" -> ScalarFunction Extract
     | other -> failwith $"Unknown function `{other}`"
 
 module Table =

--- a/src/OpenDiffix.Core/NoiseLayers.fs
+++ b/src/OpenDiffix.Core/NoiseLayers.fs
@@ -22,6 +22,7 @@ let private functionSeedMaterial =
   | RoundBy -> "round"
   | WidthBucket -> "width_bucket"
   | DateTrunc -> "date_trunc"
+  | Extract -> "extract"
   | _ -> failwith "Unsupported function used for defining buckets."
 
 let private collectSeedMaterials rangeColumns expression =

--- a/src/OpenDiffix.Core/Parser.fs
+++ b/src/OpenDiffix.Core/Parser.fs
@@ -85,9 +85,43 @@ module QueryParser =
     <|> word "boolean"
     <|> word "timestamp"
 
+  let datePartName =
+    word "seconds"
+    <|> word "second"
+    <|> word "epoch"
+    <|> word "minutes"
+    <|> word "minute"
+    <|> word "hours"
+    <|> word "hour"
+    <|> word "days"
+    <|> word "day"
+    <|> word "dow"
+    <|> word "doy"
+    <|> word "isodow"
+    <|> word "weeks"
+    <|> word "week"
+    <|> word "months"
+    <|> word "month"
+    <|> word "quarter"
+    <|> word "years"
+    <|> word "year"
+    <|> word "isoyear"
+    <|> word "decades"
+    <|> word "decade"
+    <|> word "century"
+    <|> word "centuries"
+    <|> word "millenniums"
+    <|> word "millennium"
+    <|> word "millennia"
+
   let castExpression =
     word "cast" >>. inParenthesis (expr .>> word "as" .>>. typeName) .>> spaces
     |>> fun (expr, typeName) -> Function("cast", [ expr; String typeName ])
+
+  let extractExpression =
+    word "extract" >>. inParenthesis (datePartName .>> word "from" .>>. expr)
+    .>> spaces
+    |>> fun (datePartName, expr) -> Function("extract", [ String datePartName; expr ])
 
   let selectedExpression = expr .>>. opt alias |>> As
 
@@ -242,6 +276,7 @@ module QueryParser =
     choice [
       (attempt selectQuery)
       (attempt castExpression)
+      (attempt extractExpression)
       (attempt functionExpression)
       inParenthesis expr
       star

--- a/src/OpenDiffix.Core/QueryValidator.fs
+++ b/src/OpenDiffix.Core/QueryValidator.fs
@@ -82,13 +82,15 @@ let private validateGeneralization accessLevel expression =
   if accessLevel <> Direct then
     match expression with
     | FunctionExpr (ScalarFunction DateTrunc, [ _; primaryArg ])
+    | FunctionExpr (ScalarFunction Extract, [ _; primaryArg ])
     | FunctionExpr (ScalarFunction _, primaryArg :: _) ->
       if not (Expression.isColumnReference primaryArg) then
         failwith "Primary argument for a generalization expression has to be a simple column reference."
     | _ -> ()
 
     match expression with
-    | FunctionExpr (ScalarFunction DateTrunc, [ secondaryArg; _ ]) ->
+    | FunctionExpr (ScalarFunction DateTrunc, [ secondaryArg; _ ])
+    | FunctionExpr (ScalarFunction Extract, [ secondaryArg; _ ]) ->
       if secondaryArg |> Expression.isConstant |> not then
         failwith "Secondary arguments for a generalization expression have to be constants."
     | FunctionExpr (ScalarFunction _, _ :: secondaryArgs) ->
@@ -98,7 +100,7 @@ let private validateGeneralization accessLevel expression =
 
   if accessLevel = PublishUntrusted then
     match expression with
-    | FunctionExpr (ScalarFunction fn, _) when List.contains fn [ Floor; Ceil; Round; DateTrunc ] -> ()
+    | FunctionExpr (ScalarFunction fn, _) when List.contains fn [ Floor; Ceil; Round; DateTrunc; Extract ] -> ()
     | FunctionExpr (ScalarFunction fn, [ _; Constant c ]) when
       List.contains fn [ FloorBy; RoundBy ] && Value.isMoneyRounded c
       ->


### PR DESCRIPTION
... and the legacy `date_part` syntax as an alias